### PR TITLE
Hello Translator

### DIFF
--- a/core-lib/Platform.ns
+++ b/core-lib/Platform.ns
@@ -34,4 +34,8 @@ class Platform usingVmMirror: vmMirror = Value (
 
     ^ errorCodeOrPromise
   )
+
+  public loadSingletonModule: path = (
+    ^ system loadSingletonModule: path usingPlatform: self.
+  )
 )

--- a/core-lib/System.ns
+++ b/core-lib/System.ns
@@ -32,6 +32,7 @@ class System usingVmMirror: vmMirror = Value (
   public arguments    = ( ^ vmMirror vmArguments: nil )
   public loadModule: filename = ( ^ vmMirror load: filename )
   public loadModule: filename nextTo: moduleObj = ( ^ vmMirror load: filename nextTo: moduleObj )
+  public loadSingletonModule: filename usingPlatform: platform = ( ^ vmMirror loadSingleton: filename usingPlatform: platform )
 
   (* Printing *)
   public printString: string = ( vmMirror printString: string )

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.compiler;
+
+import static som.vm.Symbols.symbolFor;
+
+import com.oracle.truffle.api.source.Source;
+
+import som.interpreter.SomLanguage;
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.literals.IntegerLiteralNode;
+import som.vm.Symbols;
+import som.vmobjects.SSymbol;
+import tools.language.StructuralProbe;
+
+
+/**
+ * This module builds SOM AST. The module categorizes its different parts:
+ *
+ * Objects:
+ * module - creates the AST for a SOM module, via the {@link MixinBuilder} class.
+ *
+ */
+public class AstBuilder {
+
+  private final ScopeManager  scopeManager;
+  private final SourceManager sourceManager;
+
+  public final Objects objectBuilder;
+
+  public AstBuilder(final Source source, final SomLanguage language,
+      final StructuralProbe probe) {
+    scopeManager = new ScopeManager(language, probe);
+    sourceManager = new SourceManager(source);
+
+    objectBuilder = new Objects();
+  }
+
+  public class Objects {
+
+    /**
+     * Creates the AST for a SOM module (although most of the construction is handled by the
+     * {@link MixinBuilder} class).
+     *
+     * First the {@link MixinBuilder} is created. We then create the primary "factory", which
+     * is a method on the module used to create instances of that module. And finally, we
+     * create a main method that simply returns zero (via the {@link MethodBuilder} class).
+     *
+     * @return - the assembled class corresponding to the module
+     */
+    public MixinDefinition module() {
+      SSymbol name = symbolFor("GraceModule");
+      MixinBuilder moduleBuilder = scopeManager.newModule(name, sourceManager.empty());
+
+      // Set up the method used to create instances
+      MethodBuilder instanceFactory = moduleBuilder.getPrimaryFactoryMethodBuilder();
+      instanceFactory.setSignature(Symbols.DEFAULT_MODULE_FACTORY);
+      instanceFactory.addArgument(Symbols.SELF, sourceManager.empty());
+      moduleBuilder.setupInitializerBasedOnPrimaryFactory(sourceManager.empty());
+      moduleBuilder.setInitializerSource(sourceManager.empty());
+      moduleBuilder.finalizeInitializer();
+
+      // Set module to inherit from object
+      moduleBuilder.setSimpleInheritance(Symbols.OBJECT, sourceManager.empty());
+
+      // Create the main method, which simply returns zero
+      MethodBuilder mainMethod = scopeManager.newMethod(Symbols.DEFAULT_MAIN_METHOD);
+      mainMethod.addArgument(Symbols.SELF, sourceManager.empty());
+      mainMethod.addArgument(Symbols.MAIN_METHOD_ARGS, sourceManager.empty());
+      mainMethod.setVarsOnMethodScope();
+      mainMethod.finalizeMethodScope();
+      ExpressionNode zero = new IntegerLiteralNode(0).initialize(sourceManager.empty());
+      scopeManager.assembleCurrentMethod(zero, sourceManager.empty());
+
+      // Assemble and return the completed module
+      return scopeManager.assumbleCurrentModule(sourceManager.empty());
+    }
+  }
+}

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -35,6 +35,7 @@ import com.oracle.truffle.api.source.Source;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.literals.IntegerLiteralNode;
+import som.interpreter.nodes.literals.StringLiteralNode;
 import som.vm.Symbols;
 import som.vmobjects.SSymbol;
 import tools.language.StructuralProbe;
@@ -52,7 +53,8 @@ public class AstBuilder {
   private final ScopeManager  scopeManager;
   private final SourceManager sourceManager;
 
-  public final Objects objectBuilder;
+  public final Objects  objectBuilder;
+  public final Literals literalBuilder;
 
   public AstBuilder(final Source source, final SomLanguage language,
       final StructuralProbe probe) {
@@ -60,6 +62,7 @@ public class AstBuilder {
     sourceManager = new SourceManager(source);
 
     objectBuilder = new Objects();
+    literalBuilder = new Literals();
   }
 
   public class Objects {
@@ -100,6 +103,16 @@ public class AstBuilder {
 
       // Assemble and return the completed module
       return scopeManager.assumbleCurrentModule(sourceManager.empty());
+    }
+  }
+
+  public class Literals {
+
+    /**
+     * Creates a SOM string literal from the given string.
+     */
+    public ExpressionNode string(final String value, final SourceSection sourceSection) {
+      return new StringLiteralNode(value).initialize(sourceSection);
     }
   }
 }

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -1,0 +1,342 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.compiler;
+
+import static som.vm.Symbols.symbolFor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.SomLanguage;
+import som.interpreter.nodes.ExpressionNode;
+import som.vmobjects.SSymbol;
+import tools.language.StructuralProbe;
+
+
+/**
+ * The JSON Tree Translator is responsible for creating SOM AST from {@link #jsonAST} (a JSON
+ * representation of Grace AST).
+ *
+ * The translator walks through each node of the JSON AST and uses the {@link AstBuilder} to
+ * generate the equivalent AST for each node. The AstBuilder may invoke the parse method on
+ * this translator (enabling recursive descent through the JSON AST), but should not interact
+ * with this translator otherwise.
+ */
+public class JsonTreeTranslator {
+
+  private final SomLanguage language;
+
+  private final SourceManager sourceManager;
+
+  private final AstBuilder astBuilder;
+  private final JsonObject jsonAST;
+
+  public JsonTreeTranslator(final JsonObject jsonAST, final Source source,
+      final SomLanguage language, final StructuralProbe probe) {
+    this.language = language;
+
+    this.sourceManager = new SourceManager(source);
+
+    this.astBuilder = new AstBuilder(this, sourceManager, language, probe);
+    this.jsonAST = jsonAST;
+  }
+
+  /**
+   * Uses the {@link SourceManager} to create a section corresponding to the source code at the
+   * given line and column.
+   */
+  private SourceSection source(final JsonObject node) {
+    int line = node.get("line").getAsInt();
+    int column = node.get("column").getAsInt();
+    return sourceManager.atLineColumn(line, column);
+  }
+
+  /**
+   * Gets the type of a {@link JsonObject}, which should be a string stored in the "nodetype"
+   * field.
+   */
+  private String nodeType(final JsonObject node) {
+    return node.get("nodetype").getAsString();
+  }
+
+  /**
+   * Gets the body of a {@link JsonObject}, which should be a {@link JsonArray} stored in the
+   * "body" field.
+   */
+  private JsonArray body(final JsonObject node) {
+    return node.get("body").getAsJsonArray();
+  }
+
+  /**
+   * Gets the name of a {@link JsonObject}, which should be a string stored in the "name"
+   * field.
+   */
+  private String name(final JsonObject node) {
+    if (node.get("name").isJsonObject()) {
+      return name(node.get("name").getAsJsonObject());
+    }
+    return node.get("name").getAsString();
+  }
+
+  /**
+   * Extracts a literal value from the {@link JsonObject}. The field containing the value
+   * depends on the type node.
+   */
+  private Object value(final JsonObject node) {
+    if (nodeType(node).equals("string-literal")) {
+      return node.get("raw").getAsString();
+
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to get a value from " + nodeType(node));
+      throw new RuntimeException();
+    }
+  }
+
+  /**
+   * Calculates the number of arguments associated with a part (a part of a request node).
+   */
+  private int countArgumentsOrParametersInPart(final JsonObject part) {
+    if (part.has("arguments")) {
+      return part.get("arguments").getAsJsonArray().size();
+    } else if (part.has("parameters")) {
+      return part.get("parameters").getAsJsonArray().size();
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to count the arguments or parameters for the part: "
+              + part);
+      throw new RuntimeException();
+    }
+
+  }
+
+  /**
+   * Gets the selector from an array of "parts", each of which contains a "name" field hosting
+   * a string value. Each part also has an "arguments" field. Each argument should represented
+   * by a `:` separator.
+   */
+  private SSymbol selectorFromParts(final JsonArray parts) {
+    String selector = "";
+    for (JsonElement element : parts) {
+      JsonObject part = element.getAsJsonObject();
+      selector += name(part);
+
+      for (int i = 0; i < countArgumentsOrParametersInPart(part); i++) {
+        selector += ":";
+      }
+    }
+
+    return symbolFor(selector);
+  }
+
+  /**
+   * Gets the receiver for a request, which should be stored in the `receiver` field.
+   */
+  private JsonObject receiver(final JsonObject node) {
+    if (node.has("receiver")) {
+      return node.get("receiver").getAsJsonObject();
+
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to get a receiver from " + nodeType(node));
+      throw new RuntimeException();
+    }
+  }
+
+  /**
+   * Gets the selector for an array of parts, given either from a request or a declaration.
+   */
+  private SSymbol selector(final JsonObject node) {
+    if (node.has("parts")) {
+      return selectorFromParts(node.get("parts").getAsJsonArray());
+
+    } else if (node.has("signature")) {
+      return selectorFromParts(
+          node.get("signature").getAsJsonObject().get("parts").getAsJsonArray());
+
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to get a name from " + nodeType(node));
+      throw new RuntimeException();
+    }
+  }
+
+  /**
+   * Gets a list of arguments nodes, each represented by a {@link JsonObject}, from a request
+   * node by iterating through the arguments belonging to each part of that request.
+   */
+  private JsonObject[] argumentsFromParts(final JsonArray parts) {
+    List<JsonObject> argumentsNodes = new ArrayList<JsonObject>();
+
+    for (JsonElement partElement : parts) {
+      JsonObject part = partElement.getAsJsonObject();
+      for (JsonElement argumentElement : part.get("arguments").getAsJsonArray()) {
+        argumentsNodes.add(argumentElement.getAsJsonObject());
+      }
+    }
+
+    return argumentsNodes.toArray(new JsonObject[argumentsNodes.size()]);
+  }
+
+  /**
+   * Gets the arguments for a request node.
+   */
+  private JsonObject[] arguments(final JsonObject node) {
+    if (node.has("parts")) {
+      return argumentsFromParts(node.get("parts").getAsJsonArray());
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to get arguments from " + node);
+      throw new RuntimeException();
+    }
+  }
+
+  /**
+   * Gets a list of parameters names, each represented by an {@link SSymbol}, from a
+   * declaration node by iterating through the parameters belonging to each part of that
+   * declaration.
+   */
+  private SSymbol[] parameterNamesFromParts(final JsonArray parts) {
+    List<SSymbol> parametersNames = new ArrayList<SSymbol>();
+
+    for (JsonElement partElement : parts) {
+      JsonObject part = partElement.getAsJsonObject();
+      for (JsonElement parameterElement : part.get("parameters").getAsJsonArray()) {
+        SSymbol name = symbolFor(name(parameterElement.getAsJsonObject()));
+        parametersNames.add(name);
+      }
+    }
+
+    return parametersNames.toArray(new SSymbol[parametersNames.size()]);
+  }
+
+  /**
+   * Gets the parameters for a declaration node.
+   */
+  private SSymbol[] parameters(final JsonObject node) {
+    if (node.has("signature")) {
+      return parameterNamesFromParts(
+          node.get("signature").getAsJsonObject().get("parts").getAsJsonArray());
+
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to get parameters from " + node);
+      throw new RuntimeException();
+    }
+  }
+
+  /**
+   * Builds an explicit send by translating the receiver and the arguments of the given
+   * request node
+   */
+  public ExpressionNode explicit(final SSymbol selector, final JsonObject receiver,
+      final JsonObject[] arguments, final SourceSection source) {
+
+    // Translate the receiver
+    ExpressionNode translateReceiver = (ExpressionNode) translate(receiver);
+
+    // Translate the arguments
+    List<ExpressionNode> argumentExpressions = new ArrayList<ExpressionNode>();
+    for (int i = 0; i < arguments.length; i++) {
+      ExpressionNode argumentExpression = (ExpressionNode) translate(arguments[i]);
+      argumentExpressions.add(argumentExpression);
+    }
+
+    return astBuilder.requestBuilder.explicit(selector, translateReceiver, argumentExpressions,
+        source);
+  }
+
+  /**
+   * Creates either a variable read (when no arguments are provided) or a message send (when
+   * arguments are provided) using the method currently at the top of the stack.
+   */
+  public ExpressionNode implicit(final SSymbol selector,
+      final JsonObject[] argumentsNodes, final SourceSection sourceSection) {
+
+    // If no arguments are provided, it's a implicit requests that can be made directly via
+    // the method
+    if (argumentsNodes.length == 0) {
+      return astBuilder.requestBuilder.implicit(selector, sourceSection);
+    }
+
+    // Otherwise, process the arguments and create a message send.
+    List<ExpressionNode> arguments = new ArrayList<ExpressionNode>();
+    for (int i = 0; i < argumentsNodes.length; i++) {
+      arguments.add((ExpressionNode) translate(argumentsNodes[i]));
+    }
+
+    // Create the message send with information from the current method
+    return astBuilder.requestBuilder.implicit(selector, arguments, sourceSection);
+  }
+
+  /**
+   * The re-entry point for the translator, which continues the translation from the given
+   * node. This method should be used by the {@link AstBuilder} in a recursive-descent style.
+   */
+  public Object translate(final JsonObject node) {
+
+    if (nodeType(node).equals("method-declaration")) {
+      astBuilder.objectBuilder.method(selector(node), parameters(node), body(node));
+      return null;
+
+    } else if (nodeType(node).equals("identifier")) {
+      return astBuilder.requestBuilder.implicit(symbolFor(name(node)), source(node));
+
+    } else if (nodeType(node).equals("implicit-receiver-request")) {
+      return implicit(selector(node), arguments(node), source(node));
+
+    } else if (nodeType(node).equals("explicit-receiver-request")) {
+      return explicit(selector(node), receiver(node), arguments(node), source(node));
+
+    } else if (nodeType(node).equals("string-literal")) {
+      return astBuilder.literalBuilder.string((String) value(node), source(node));
+
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand what to do with a " + nodeType(node) + " node?");
+      throw new RuntimeException();
+    }
+  }
+
+  /**
+   * The entry point for the translator, which begins the translation at the module level.
+   */
+  public MixinDefinition translateModule() {
+    JsonObject moduleNode = jsonAST.get("module").getAsJsonObject();
+    JsonArray body = body(moduleNode);
+
+    return astBuilder.objectBuilder.module(body);
+  }
+}

--- a/src/som/compiler/KernanClient.java
+++ b/src/som/compiler/KernanClient.java
@@ -1,0 +1,514 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.compiler;
+
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ConnectException;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.oracle.truffle.api.source.Source;
+
+import som.VM;
+import som.interpreter.SomLanguage;
+import tools.language.StructuralProbe;
+
+
+/**
+ * This module is a utility for the {@link SourcecodeCompiler} class and is responsible for
+ * parsing Grace programs via Kernan (@see
+ * <a href="http://gracelang.org/applications/grace-versions/kernan/">Kernan</a>), a C#-based
+ * Grace interpreter.
+ *
+ * In order to talk over the wire, both Kernan and this client partially implement the
+ * Websocket protocol (RFC 6455). First a {@link Socket} is opened and then the upgrade message
+ * is sent as a standard HTTP request (@see {@link #upgrade()}. Once processed, both Kernan and
+ * this client switch into web-socket mode.
+ *
+ * Once in web-socket mode, the {@link Sender} and {@link Receiver} classes enable the two-way
+ * asynchronous communication. Each implements a stack of {@link Frame} objects: whenever a
+ * message is received it is read from the stream, decoded into a frame, and then added to the
+ * stack; and whenever this client wants to send a message it is first encoded to a frame and
+ * then added to the stack. The {@link Executors} module is used to run the sender and the
+ * receiver asynchronously.
+ *
+ * The client continues to wait until a parse-tree response is received from Kernan. In
+ * particular, the {@link Receiver} continues to process until it finds this response (and
+ * currently ignores all other responses). Once found, the contents of the parse-tree message
+ * are used to complete the {@link #futureToCompleteWithParseTree}. Once this future has been
+ * completed, this client will send a frame asking Kernan to stop listening and then closing
+ * the socket. Finally, the client parses the parse-tree message into a {@link JsonObject}
+ * and returns this object to the {@link SourcecodeCompiler}.
+ *
+ * While neither implementation is strictly compliant, the current implementation seems to be
+ * sufficient for sending code to Kernan and receiving back a JSON-based parse tree.
+ */
+public class KernanClient {
+
+  private final static String address = "127.0.0.1";
+  private final static int    port    = 25447;
+
+  // RFC operation codes
+  private final static int OPCODE_RUN   = 1;
+  private final static int OPCODE_CLOSE = 8;
+
+  private final Source   source;
+  private final VM       vm;
+  private final Socket   socket;
+  private final Sender   sender;
+  private final Receiver receiver;
+
+  private CompletableFuture<String> futureToCompleteWithParseTree;
+
+  /**
+   * This frame class partially implements the frame data structure defined by the Web-socket
+   * protocol, @see <a href="https://tools.ietf.org/html/rfc6455">RFC 6455</a>.
+   *
+   * Messages that fit into one frame (no more than 65536 bytes) can be sent. If it becomes
+   * necessary, I will extend this class to allow messages to span multiple frames.
+   *
+   * Note: frames can only be created using the {@link KernanClient#buildFrame} method, in
+   * which both the operation code and the message should be provided directly. Instances of
+   * frame objects may only be used to query
+   *
+   */
+  private class Frame {
+    private final static int OPCODE_INDEX        = 0;
+    private final static int MESSAGE_126_INDEX   = 6;
+    private final static int MESSAGE_65536_INDEX = 8;
+
+    private final byte[] data;
+
+    private Frame(final int len) {
+      if (len < 126) {
+        data = new byte[MESSAGE_126_INDEX + len];
+      } else {
+        data = new byte[MESSAGE_65536_INDEX + len];
+      }
+    }
+
+    private void setOperationCode(final int code) {
+      data[OPCODE_INDEX] = (byte) code;
+    }
+
+    private void setMessageWithLenLessThan126(final String message) {
+      boolean correct = data.length == (message.length() + MESSAGE_126_INDEX);
+      assert correct : "Message was not the correct size?";
+
+      data[1] = (byte) message.length();
+      for (int i = 0; i < message.length(); i++) {
+        char c = message.charAt(i);
+        data[MESSAGE_126_INDEX + i] = (byte) c;
+      }
+    }
+
+    private void setMessageWithLenGreaterThanOrEqual126(final String message) {
+      boolean correct = data.length == (message.length() + MESSAGE_65536_INDEX);
+      assert correct : "Message was not the correct size?";
+
+      short messageLenIn16bits = (short) message.length();
+      data[1] = (byte) 126;
+      data[2] = (byte) ((messageLenIn16bits >> 8) & 0xFF);
+      data[3] = (byte) (messageLenIn16bits & 0xFF);
+
+      for (int i = 0; i < message.length(); i++) {
+        char c = message.charAt(i);
+        data[MESSAGE_65536_INDEX + i] = (byte) c;
+      }
+
+      return;
+    }
+
+    private void setMessage(final String message) {
+      if (data.length < 126) {
+        setMessageWithLenLessThan126(message);
+      } else {
+        setMessageWithLenGreaterThanOrEqual126(message);
+      }
+    }
+
+    public byte[] getBytes() {
+      return data;
+    }
+  }
+
+  /**
+   * Builds a web-socket frame, containing the given operation code and message, that can be
+   * sent over the wire to Kernan.
+   *
+   * @param operationCode - the RFC operation code
+   * @param message - the message to send
+   * @return - an instance of {@link Frame}
+   */
+  public Frame buildFrame(final int operationCode, final String message) {
+    Frame frame = new Frame(message.length());
+    frame.setOperationCode(operationCode);
+    frame.setMessage(message);
+    return frame;
+  }
+
+  /**
+   * Performs initialization of the client, which includes opening an HTTP socket and then
+   * sending a request, via {@link #upgrade()}, to change to web-socket mode.
+   *
+   * Also creates the sender and receiver objects used to run the two-way communication for
+   * this websocket.
+   */
+  public KernanClient(final Source source, final SomLanguage language,
+      final StructuralProbe structuralProbe) {
+    this.source = source;
+    this.vm = language.getVM();
+
+    try {
+      this.socket = new Socket(address, port);
+    } catch (ConnectException e) {
+      vm.errorExit("Nothing is sending data on " + address + ":" + port
+          + ". Did you start Kernan in websocket mode?");
+      throw new RuntimeException();
+    } catch (IOException e) {
+      vm.errorExit("Failed to create a generic socket on " + address + "(" + port + ")");
+      throw new RuntimeException();
+    }
+
+    try {
+      upgrade();
+    } catch (IOException e) {
+      vm.errorExit("failed to initialize websocket: " + e.getMessage());
+      throw new RuntimeException();
+    }
+
+    this.sender = new Sender();
+    this.receiver = new Receiver();
+  }
+
+  /**
+   * Closes the socket by sending the close operation code to Kernan.
+   */
+  private void close() {
+    Frame frame = buildFrame(OPCODE_CLOSE, "");
+    sendFrame(frame);
+    sender.sendAnyRemainingFramesAndClose();
+  }
+
+  /**
+   * A utility used to process frames received from Kernan.
+   *
+   * Data is read directly from the socket via the {@link DataInputStream}; note that the read
+   * requests will block until the corresponding bytes become available. When run, the receiver
+   * collects all frames received over the wire. As soon as a frame containing the parse-tree
+   * is found, the {@link KernanClient#futureToCompleteWithParseTree} future is completed,
+   * after which point this client will close the socket and then return the parse tree.
+   */
+  private class Receiver implements Runnable {
+
+    private final DataInputStream stream;
+
+    private final Stack<Frame> frames;
+
+    public Receiver() {
+      frames = new Stack<Frame>();
+
+      try {
+        stream = new DataInputStream(socket.getInputStream());
+      } catch (IOException e) {
+        vm.errorExit("Receiver failed to get input stream for socket:" + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+
+    /**
+     * Reads an entry from the stream, casting it to a byte.
+     */
+    private byte read() {
+      try {
+        return (byte) stream.read();
+      } catch (IOException e) {
+        vm.errorExit("Receiver failed to read from stream: " + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+
+    /**
+     * Reads a single byte from the stream.
+     */
+    private byte readByte() {
+      try {
+        return stream.readByte();
+      } catch (IOException e) {
+        vm.errorExit("Websocket failed to read short:" + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+
+    /**
+     * Reads enough bytes from the stream to compose an unsigned short.
+     */
+    private int readLengthGreaterThan126() {
+      try {
+        return stream.readUnsignedShort();
+      } catch (IOException e) {
+        vm.errorExit("Websocket failed to read short:" + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+
+    /**
+     * This method examines the structure of the given message to decide whether or not it
+     * contains a parse tree.
+     *
+     * @param message - the given message
+     * @return - true when the given message contains a parse-tree
+     */
+    public boolean messageContainsParseTree(final String message) {
+      JsonObject root = new JsonParser().parse(message).getAsJsonObject();
+      return root.has("event") && root.get("event").getAsString().equals("parse-tree");
+    }
+
+    /**
+     * This method will cause continue to read frames sent from Kernan until it finds a message
+     * containing a parse-tree. Note that this method will add each frame to the stack and
+     * block until the desired parse-tree frame is found.
+     */
+    @Override
+    public void run() {
+      byte opByte = read();
+      byte lenByte = read();
+
+      // Check that the message is contained within just one frame
+      int fin = ((opByte >> 0) & 1);
+      if (fin != 1) {
+        vm.errorExit("The client cannot yet process messages that span more than one frame");
+        throw new RuntimeException();
+      }
+
+      // Get the web-socket operation code
+      int op = (opByte + 128);
+
+      // Get the length of the message
+      int len = lenByte;
+      if (len == 126) {
+        len = readLengthGreaterThan126();
+      }
+
+      // And parse the message itself
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < len; i++) {
+        char c = (char) readByte();
+        builder.append(c);
+      }
+      String message = builder.toString();
+
+      // Record the message to the stack
+      frames.add(buildFrame(op, message));
+
+      // Either complete the future (when a parse tree is found) or read the next frame
+      if (messageContainsParseTree(message)) {
+        futureToCompleteWithParseTree.complete(message);
+      } else {
+        run();
+      }
+    }
+  }
+
+  /**
+   * A utility used to process send frames to Kernan.
+   *
+   * When run the sender sends all frames in its stack over the wire to Kernan, via a
+   * {@link DataOutputStream} created from the socket.
+   */
+  private class Sender implements Runnable {
+
+    private final Stack<Frame>     frames;
+    private final DataOutputStream stream;
+
+    public Sender() {
+      frames = new Stack<Frame>();
+
+      try {
+        stream = new DataOutputStream(socket.getOutputStream());
+      } catch (IOException e) {
+        vm.errorExit("Sender failed to get output stream for socket:" + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+
+    /**
+     * Used to add a frame object to the queue.
+     */
+    public void addFrame(final Frame frame) {
+      frames.add(frame);
+    }
+
+    /**
+     * When run, the sender pops each frame off the stack and sends it to Kernan.
+     *
+     * NOTE: will it ever matter that message are sent in a first-in-last-out order?
+     */
+    @Override
+    public void run() {
+      while (frames.size() > 0) {
+        Frame frame = frames.pop();
+        byte[] bytes = frame.getBytes();
+        try {
+          stream.write(bytes);
+        } catch (IOException e) {
+          vm.errorExit("Sender failed to write byte to stream: " + e.getMessage());
+          throw new RuntimeException();
+        }
+      }
+    }
+
+    /**
+     * Used by {@link KernanClient#close()} to send any remaining frames, to Kernan, before the
+     * socket is closed.
+     */
+    public void sendAnyRemainingFramesAndClose() {
+      run();
+      try {
+        socket.close();
+      } catch (IOException e) {
+        vm.errorExit("Sender was not able to close the socket: " + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+  }
+
+  /**
+   * Adds a frame to the send queue and then runs the sender.
+   */
+  public void sendFrame(final Frame frame) {
+    sender.addFrame(frame);
+    Executors.newCachedThreadPool().submit(sender);
+  }
+
+  /**
+   * Blocks until a parse-tree message has been received.
+   */
+  public void waitForParseTreeResponse() {
+    Executors.newCachedThreadPool().submit(receiver);
+  }
+
+  /**
+   * Sends a HTTP request to change the protocol used over the socket from HTTP to Web-Socket.
+   *
+   * A {@link PrintWriter} is used to write the HTTP request to the stream and a
+   * {@link BufferedReader} is used to read the response from the server.
+   *
+   * Upon receiving a response from Kernan the response message is checked and, provided that
+   * it was accepted, this client continues under the assumption that communication will now be
+   * performed through frames.
+   */
+  private void upgrade() throws IOException {
+    PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+
+    // Build and send the Websocket upgrade request
+    StringBuilder requestBuilder = new StringBuilder();
+    requestBuilder.append("GET /grace HTTP/1.1\r\n");
+    requestBuilder.append("Host: 127.0.0.1\r\n");
+    requestBuilder.append("Connection: Upgrade\r\n");
+    requestBuilder.append("Upgrade: h2c\r\n");
+    requestBuilder.append("Sec-WebSocket-Key: moth\r\n");
+    out.println(requestBuilder.toString());
+
+    // Read the response until an empty line is found
+    BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+    StringBuilder response = new StringBuilder();
+    String inputLine;
+
+    int linesProcessed = 0;
+    while ((inputLine = in.readLine()) != null && linesProcessed < 1000) {
+      linesProcessed += 1;
+      response.append(inputLine + "\n");
+
+      // The HTTP response has been processed, check whether the change in protocol was
+      // accepted by Kernan.
+      if (inputLine.length() == 0) {
+        if (response.toString().contains("Sec-WebSocket-Accept:")) {
+          return;
+        } else {
+          vm.errorExit("Kernan refused to upgrade to web-socket communication?");
+        }
+      }
+    }
+
+    vm.errorExit(
+        "After processing a thousands lines, no end to the response from Kernan was found. Current response:\n "
+            + in.toString());
+    throw new RuntimeException();
+  }
+
+  /**
+   * Encodes the given source code into a Web-socket frame and sends it to Kernan via the
+   * {@link Sender}. This method then blocks until the parse tree response, from Kernan, has
+   * been processed by the {@link Receiver}. The socket is then closed and the parse tree is
+   * decoded from the message.
+   *
+   * @return a {@link JsonObject} representing the decoded parse tree.
+   */
+  public JsonObject getParseTree() {
+
+    // Build and send the frame.
+    final Map<String, String> data = new HashMap<String, String>();
+    data.put("mode", "parse");
+    data.put("code", source.getCharacters().toString());
+    data.put("modulename", source.getURI().getPath());
+    Frame frame = buildFrame(OPCODE_RUN, new Gson().toJson(data));
+    sendFrame(frame);
+
+    // Wait for the receiver to complete the message
+    futureToCompleteWithParseTree = new CompletableFuture<>();
+    waitForParseTreeResponse();
+    String message;
+    try {
+      message = futureToCompleteWithParseTree.get();
+    } catch (InterruptedException | ExecutionException e) {
+      vm.errorExit("KernanClient failed to get future: " + e.getMessage());
+      throw new RuntimeException();
+    }
+
+    // Close the socket and return the parse tree
+    close();
+    JsonObject asJson = new JsonParser().parse(message).getAsJsonObject();
+    JsonObject parseTree = asJson.get("data").getAsJsonObject();
+    return parseTree;
+  }
+}

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -604,6 +604,23 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
     return superFactorySend;
   }
 
+  /**
+   * Configures this class being built to inherit from the named super class. The named
+   * superclass must be found via a simple self send.
+   *
+   * @param superclassName - the name of the superclass
+   * @param sourceSection
+   */
+  public void setSimpleInheritance(final SSymbol superclassName,
+      final SourceSection sourceSection) {
+    MethodBuilder def = getClassInstantiationMethodBuilder();
+    ExpressionNode selfRead = def.getSelfRead(sourceSection);
+    ExpressionNode superClass = SNodeFactory.createMessageSend(superclassName,
+        new ExpressionNode[] {selfRead}, false, sourceSection, null, language);
+    setSuperClassResolution(superClass);
+    setSuperclassFactorySend(createStandardSuperFactorySend(sourceSection), true);
+  }
+
   public static SSymbol getSetterName(final SSymbol selector) {
     assert !selector.getString().endsWith(":");
     return symbolFor(selector.getString() + ":");

--- a/src/som/compiler/NewspeakParser.java
+++ b/src/som/compiler/NewspeakParser.java
@@ -118,7 +118,7 @@ import tools.debugger.Tags.StatementSeparatorTag;
 import tools.language.StructuralProbe;
 
 
-public class Parser {
+public class NewspeakParser {
 
   protected final Lexer lexer;
   private final Source  source;
@@ -177,7 +177,7 @@ public class Parser {
     private final Symbol           expected;
     private final Symbol           found;
 
-    ParseError(final String message, final Symbol expected, final Parser parser) {
+    ParseError(final String message, final Symbol expected, final NewspeakParser parser) {
       super(message);
       if (parser.lexer == null) {
         this.sourceCoordinate = new SourceCoordinate(0, 0, 0, 0);
@@ -205,7 +205,7 @@ public class Parser {
       String msg = super.getMessage();
 
       String foundStr;
-      if (Parser.printableSymbol(found)) {
+      if (NewspeakParser.printableSymbol(found)) {
         foundStr = found + " (" + text + ")";
       } else {
         foundStr = found.toString();
@@ -222,7 +222,7 @@ public class Parser {
     public String toString() {
       String msg = "%(file)s:%(line)d:%(column)d: error: " + super.getMessage();
       String foundStr;
-      if (Parser.printableSymbol(found)) {
+      if (NewspeakParser.printableSymbol(found)) {
         foundStr = found + " (" + text + ")";
       } else {
         foundStr = found.toString();
@@ -245,7 +245,7 @@ public class Parser {
     private final Symbol[]    expectedSymbols;
 
     ParseErrorWithSymbols(final String message, final Symbol[] expected,
-        final Parser parser) {
+        final NewspeakParser parser) {
       super(message, null, parser);
       this.expectedSymbols = expected;
     }
@@ -264,7 +264,7 @@ public class Parser {
     }
   }
 
-  public Parser(final String content, final long fileSize, final Source source,
+  public NewspeakParser(final String content, final long fileSize, final Source source,
       final StructuralProbe structuralProbe, final SomLanguage language) throws ParseError {
     this.source = source;
     this.language = language;

--- a/src/som/compiler/ScopeManager.java
+++ b/src/som/compiler/ScopeManager.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.compiler;
+
+import java.util.Stack;
+
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.VM;
+import som.compiler.MixinBuilder.MixinDefinitionError;
+import som.interpreter.SomLanguage;
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.SequenceNode;
+import som.vmobjects.SInvokable;
+import som.vmobjects.SSymbol;
+import tools.language.StructuralProbe;
+
+
+/**
+ * The scope manager is a utility for use with {@link AstBuilder}. It is responsible for the
+ * creation and assembly of the SOM scope builders, which are the {@link MethodBuilder} and the
+ * {@link MixinBuilder}.
+ *
+ * The scope stores each builder using two {@link Stack}s, one for objects and another for
+ * methods. When a builder is created it is added to the corresponding stack and, similarly,
+ * when a builder is assembled it is removed from the stack.
+ *
+ * The `peek` methods can be used, in {@link AstBuilder} to query the method / object currently
+ * at the top of the stack.
+ *
+ * Finally the scope manager holds a reference to {@link SomLanguage}, which it uses to access
+ * through errors (via {@link VM}, and {@link StructuralProbe}, which is used by SOMns used to
+ * track structural information.
+ */
+public class ScopeManager {
+
+  private final SomLanguage     language;
+  private final StructuralProbe probe;
+
+  private final Stack<MixinBuilder>  objects;
+  private final Stack<MethodBuilder> methods;
+
+  public ScopeManager(final SomLanguage language, final StructuralProbe probe) {
+    this.language = language;
+    this.probe = probe;
+    this.objects = new Stack<MixinBuilder>();
+    this.methods = new Stack<MethodBuilder>();
+  }
+
+  public void pushObject(final MixinBuilder builder) {
+    objects.push(builder);
+  }
+
+  public void pushMethod(final MethodBuilder builder) {
+    methods.push(builder);
+  }
+
+  public MethodBuilder popMethod() {
+    return methods.pop();
+  }
+
+  public MixinBuilder popObject() {
+    return objects.pop();
+  }
+
+  public MethodBuilder peekMethod() {
+    return methods.peek();
+  }
+
+  public MixinBuilder peekObject() {
+    return objects.peek();
+  }
+
+  /**
+   * Creates a builder that makes a module, which in Newspeak is an object surrounded by nil.
+   *
+   * @param name - the name for the module
+   * @param sourceSection - the source for the module (can be line 1, column 1 of the source
+   *          code)
+   * @return the builder
+   */
+  public MixinBuilder newModule(final SSymbol name, final SourceSection sourceSection) {
+    MixinBuilder builder =
+        new MixinBuilder(null, // ensures the resulting object is surrounded by nil
+            AccessModifier.PUBLIC, // not sure if this is required to be PUBLIC
+            name,
+            sourceSection, probe, language);
+    pushObject(builder);
+    return builder;
+  }
+
+  /**
+   * Creates a builder that makes a method for the object sitting at the top of the object
+   * stack
+   *
+   * @param name - the name for the module
+   * @param sourceSection - the source for the module (can be line 1, column 1 of the source
+   *          code)
+   * @return the builder
+   */
+  public MethodBuilder newMethod(final SSymbol signature) {
+    MethodBuilder builder = new MethodBuilder(peekObject(), probe);
+    builder.setSignature(signature);
+    methods.push(builder);
+    return builder;
+  }
+
+  /**
+   * Assembles an invokable method that performs the give expression. Once the method has been
+   * assembled, the finish SOM method is added to the object at the top of the stack.
+   *
+   * @param body - an {@link ExpressionNode} or a sequence of them (via {@link SequenceNode})
+   * @param sourceSection
+   */
+  public void assembleCurrentMethod(final ExpressionNode body,
+      final SourceSection sourceSection) {
+    MethodBuilder builder = popMethod();
+    SInvokable ivk = builder.assemble(body, AccessModifier.PUBLIC, sourceSection);
+
+    try {
+      peekObject().addMethod(ivk);
+    } catch (MixinDefinitionError e) {
+      language.getVM().errorExit("Failed to add " + builder.getSignature() + " to "
+          + peekObject().getName() + ":" + e.getMessage());
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Produces a finished class definition by assembling the object at the top of the stack.
+   * Since this method is used to assemble SOM modules, which are enclosing by nil, the stack
+   * must contain precisely one element.
+   *
+   * @param sourceSection
+   * @return - a SOM class definition
+   */
+  public MixinDefinition assumbleCurrentModule(final SourceSection sourceSection) {
+    assert objects.size() == 1 : "There must be exactly one object left in the stack when assembling a module";
+    return popObject().assemble(sourceSection);
+  }
+}

--- a/src/som/compiler/SourceManager.java
+++ b/src/som/compiler/SourceManager.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.compiler;
+
+import java.util.Arrays;
+
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.vmobjects.SSymbol;
+
+
+/**
+ * The source manager, a utility for {@link AstBuilder} is responsible for distributing
+ * sections of the source code and providing other information about the source code (such as
+ * the module name).
+ */
+public class SourceManager {
+  private Source source;
+
+  SourceManager(final Source source) {
+    this.source = source;
+  }
+
+  /**
+   * Creates a section that doesn't correspond to any part of the source code
+   */
+  public SourceSection empty() {
+    return source.createUnavailableSection();
+  }
+
+  /**
+   * Creates a section starting at the given line and column, spanning exactly one character.
+   */
+  public SourceSection atLineColumn(final int line, final int column) {
+    return source.createSection(line, column, 1);
+  }
+
+  /**
+   * Returns the name of the module, from which the source code came, by extracting the
+   * filename from the source's filepath.
+   */
+  public String getModuleName() {
+    String path = source.getPath();
+    String[] pathParts = path.split("/");
+    String filePart = pathParts[pathParts.length - 1];
+    return filePart.split("\\.")[0];
+  }
+
+  /**
+   * Calculates the path for the named module as relative to the current module, unless the
+   * named module a built-in module (in which case a predetermined path is provided).
+   *
+   * @param moduleName
+   * @return
+   */
+  public String pathForModuleNamed(final SSymbol moduleName) {
+    if (moduleName.getString().equals("standardGrace")) {
+      return System.getenv("MOTH_HOME") + "/GraceLibrary/Modules/standardGrace.grace";
+    }
+    String[] pathParts = source.getPath().split("/");
+    String[] pathPartsWithoutFilename = Arrays.copyOfRange(pathParts, 0, pathParts.length - 1);
+    String directory = String.join("/", pathPartsWithoutFilename);
+    return directory + "/" + moduleName.getString() + ".grace";
+  }
+}

--- a/src/som/compiler/SourcecodeCompiler.java
+++ b/src/som/compiler/SourcecodeCompiler.java
@@ -71,11 +71,12 @@ public class SourcecodeCompiler {
   public MixinDefinition compileGraceModule(final Source source,
       final StructuralProbe structuralProbe)
       throws ProgramDefinitionError {
-    AstBuilder astBuilder = new AstBuilder(source, language, structuralProbe);
     KernanClient client = new KernanClient(source, language, structuralProbe);
-
     JsonObject parseTree = client.getParseTree();
-    MixinDefinition result = astBuilder.objectBuilder.module();
+    JsonTreeTranslator translator =
+        new JsonTreeTranslator(parseTree, source, language, structuralProbe);
+
+    MixinDefinition result = translator.translateModule();
     language.getVM().reportLoadedSource(source);
     return result;
   }

--- a/src/som/compiler/SourcecodeCompiler.java
+++ b/src/som/compiler/SourcecodeCompiler.java
@@ -24,6 +24,7 @@
 
 package som.compiler;
 
+import com.google.gson.JsonObject;
 import com.oracle.truffle.api.source.Source;
 
 import bd.basic.ProgramDefinitionError;
@@ -71,6 +72,9 @@ public class SourcecodeCompiler {
       final StructuralProbe structuralProbe)
       throws ProgramDefinitionError {
     AstBuilder astBuilder = new AstBuilder(source, language, structuralProbe);
+    KernanClient client = new KernanClient(source, language, structuralProbe);
+
+    JsonObject parseTree = client.getParseTree();
     MixinDefinition result = astBuilder.objectBuilder.module();
     language.getVM().reportLoadedSource(source);
     return result;

--- a/src/som/compiler/SourcecodeCompiler.java
+++ b/src/som/compiler/SourcecodeCompiler.java
@@ -47,12 +47,13 @@ public class SourcecodeCompiler {
   public MixinDefinition compileModule(final Source source,
       final StructuralProbe structuralProbe)
       throws ProgramDefinitionError {
-    Parser parser = new Parser(source.getCharacters().toString(), source.getLength(), source,
-        structuralProbe, language);
+    NewspeakParser parser =
+        new NewspeakParser(source.getCharacters().toString(), source.getLength(), source,
+            structuralProbe, language);
     return compile(parser, source);
   }
 
-  protected final MixinDefinition compile(final Parser parser,
+  protected final MixinDefinition compile(final NewspeakParser parser,
       final Source source) throws ProgramDefinitionError {
     SourceCoordinate coord = parser.getCoordinate();
     MixinBuilder mxnBuilder = parser.moduleDeclaration();

--- a/src/som/compiler/SourcecodeCompiler.java
+++ b/src/som/compiler/SourcecodeCompiler.java
@@ -44,21 +44,52 @@ public class SourcecodeCompiler {
     return language;
   }
 
-  public MixinDefinition compileModule(final Source source,
+  /**
+   * Builds a SOM module using the {@link NewspeakParser}.
+   *
+   * @return - a finished SOM class created from the given module
+   */
+  public MixinDefinition compileSomModule(final Source source,
       final StructuralProbe structuralProbe)
       throws ProgramDefinitionError {
     NewspeakParser parser =
         new NewspeakParser(source.getCharacters().toString(), source.getLength(), source,
             structuralProbe, language);
-    return compile(parser, source);
-  }
-
-  protected final MixinDefinition compile(final NewspeakParser parser,
-      final Source source) throws ProgramDefinitionError {
     SourceCoordinate coord = parser.getCoordinate();
     MixinBuilder mxnBuilder = parser.moduleDeclaration();
     MixinDefinition result = mxnBuilder.assemble(parser.getSource(coord));
     language.getVM().reportLoadedSource(source);
     return result;
+  }
+
+  /**
+   * Builds a SOM module whose main method simply returns zero.
+   *
+   * @return - a finished SOM class created from the given module
+   */
+  public MixinDefinition compileGraceModule(final Source source,
+      final StructuralProbe structuralProbe)
+      throws ProgramDefinitionError {
+    AstBuilder astBuilder = new AstBuilder(source, language, structuralProbe);
+    MixinDefinition result = astBuilder.objectBuilder.module();
+    language.getVM().reportLoadedSource(source);
+    return result;
+  }
+
+  /**
+   * Compiles a program, which must be written in either Grace or Newspeak.
+   *
+   * @return - a finished SOM class created from the given module
+   */
+  public MixinDefinition compileModule(final Source source,
+      final StructuralProbe structuralProbe)
+      throws ProgramDefinitionError {
+    final String path = source.getURI().getPath();
+
+    if (path.endsWith(".grace") || path.endsWith(".grc")) {
+      return compileGraceModule(source, structuralProbe);
+    } else {
+      return compileSomModule(source, structuralProbe);
+    }
   }
 }

--- a/src/som/compiler/TypeParser.java
+++ b/src/som/compiler/TypeParser.java
@@ -16,14 +16,14 @@ import static som.compiler.Symbol.Or;
 import static som.compiler.Symbol.Period;
 import static som.compiler.Symbol.RCurly;
 
-import som.compiler.Parser.ParseError;
+import som.compiler.NewspeakParser.ParseError;
 
 
 public class TypeParser {
 
-  private final Parser parser;
+  private final NewspeakParser parser;
 
-  public TypeParser(final Parser parser) {
+  public TypeParser(final NewspeakParser parser) {
     this.parser = parser;
   }
 

--- a/src/som/vm/Symbols.java
+++ b/src/som/vm/Symbols.java
@@ -41,6 +41,10 @@ public final class Symbols implements IdProvider<SSymbol> {
   public static final SSymbol METACLASS       = symbolFor("Metaclass");
   public static final SSymbol METACLASS_CLASS = symbolFor("Metaclass class");
 
+  public static final SSymbol DEFAULT_MODULE_FACTORY = symbolFor("usingPlatform:");
+  public static final SSymbol DEFAULT_MAIN_METHOD    = symbolFor("main:");
+  public static final SSymbol MAIN_METHOD_ARGS       = symbolFor("args");
+
   public static final SSymbol SUPER = symbolFor("super");
 
   public static final SSymbol SELF       = symbolFor("self");

--- a/src/som/vm/Symbols.java
+++ b/src/som/vm/Symbols.java
@@ -54,4 +54,11 @@ public final class Symbols implements IdProvider<SSymbol> {
   public static final SSymbol Kernel = symbolFor("Kernel");
 
   public static final Symbols PROVIDER = new Symbols();
+
+  public static final SSymbol PLATFORM_MODULE = symbolFor("platform");
+  public static final SSymbol SYSTEM_MODULE   = symbolFor("system");
+
+  public static final SSymbol LOAD_SINGLETON_MODULE = symbolFor("loadSingletonModule:");
+
+  public static final SSymbol SECRET_DIALECT_SLOT = symbolFor("dialect");
 }

--- a/tests/java/som/compiler/TypeGrammarParserTest.java
+++ b/tests/java/som/compiler/TypeGrammarParserTest.java
@@ -9,7 +9,7 @@ import com.oracle.truffle.api.source.MissingMIMETypeException;
 import com.oracle.truffle.api.source.MissingNameException;
 import com.oracle.truffle.api.source.Source;
 
-import som.compiler.Parser.ParseError;
+import som.compiler.NewspeakParser.ParseError;
 import som.interpreter.SomLanguage;
 import tools.language.StructuralProbe;
 
@@ -55,7 +55,7 @@ public class TypeGrammarParserTest {
       throws MissingMIMETypeException, MissingNameException, ParseError {
     Source s =
         Source.newBuilder(testString).name("test.ns").mimeType(SomLanguage.MIME_TYPE).build();
-    Parser p = new Parser(
+    NewspeakParser p = new NewspeakParser(
         testString, testString.length(), s, new StructuralProbe(),
         new SomLanguage());
 


### PR DESCRIPTION
The code added between these commits is sufficient for executing the Grace program: `print("Hello World")`. Despite the simple appearance, running this particular expression requires not only the translation of the string literal and the surrounding implicit requests but also the parsing of the default dialect, which entails method declarations and both implicit and explicit requests.

The core of the changes presented here are a pair of modules named the `JsonTreeTranslator` and the `AstBuilder`. These two modules work together to translate Grace AST in SOM AST and, by performing this translation effectively, we can execute Grace programs directly on SOMns.

The Grace AST is not parsed directly in SOMns. Instead, we send source code to [Kernan](http://gracelang.org/applications/grace-versions/kernan/) via a websocket interface and, in turn, receive parse tree, expressed in terms of a JSON data structure.
 
The `JsonTreeTranslator` and `AstBuilder` walk through this tree in a recursive-descent style. The translator starts from the root node (a module) and executes the builder's module method. The builder first assembles the SOM AST for a module declaration. It then iterates through each of the Grace module's body nodes and asks the translator to translate each one. The translator extracts information from the nodes and then calls the builder again to compose the SOM AST for each those nodes, which might be message requests, literals, or method declarations (more will be added in later development).

The current implementation translates Grace's module and method declarations, dialect requests, implicit and explicit message requests, and also its string literals; sufficient for executing Grace's "hello world" example.

Finally, I have introduced two utilities modules: the `SourceManager` and the `ScopeManager`. The source manager is responsible for providing information about the source code and its location in the file system. The scope manager is responsible for recording the object and method nesting during translation. Both modules can be accessed by both the `JsonTreeTranslator` and `AstBuilder`.