### PR TITLE
Upgraded translation

### DIFF
--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -87,7 +87,7 @@ public class AstBuilder {
      * Adds an immutable slot to the object currently at the top of stack. The slot will be
      * initialized by executing the given expressions.
      */
-    private void addImmutableSlot(final SSymbol slotName, final ExpressionNode init,
+    public void addImmutableSlot(final SSymbol slotName, final ExpressionNode init,
         final SourceSection sourceSection) {
       try {
         scopeManager.peekObject().addSlot(slotName, AccessModifier.PUBLIC, true, init,

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -42,6 +42,9 @@ import som.compiler.MixinBuilder.MixinDefinitionError;
 import som.interpreter.SNodeFactory;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.literals.BooleanLiteralNode.FalseLiteralNode;
+import som.interpreter.nodes.literals.BooleanLiteralNode.TrueLiteralNode;
+import som.interpreter.nodes.literals.DoubleLiteralNode;
 import som.interpreter.nodes.literals.IntegerLiteralNode;
 import som.interpreter.nodes.literals.StringLiteralNode;
 import som.vm.Symbols;
@@ -232,6 +235,9 @@ public class AstBuilder {
      * at the top of the stack.
      */
     public ExpressionNode implicit(final SSymbol name, final SourceSection sourceSection) {
+      if (name.getString().equals("true") || name.getString().equals("false")) {
+        return literalBuilder.bool(name.getString(), sourceSection);
+      }
       MethodBuilder method = scopeManager.peekMethod();
       return method.getImplicitReceiverSend(name, sourceSection);
     }
@@ -274,6 +280,24 @@ public class AstBuilder {
   }
 
   public class Literals {
+
+    /**
+     * Creates a SOM boolean literal from the given string.
+     */
+    public ExpressionNode bool(final String value, final SourceSection sourceSection) {
+      if (value.equals("true")) {
+        return new TrueLiteralNode().initialize(sourceSection);
+      } else {
+        return new FalseLiteralNode().initialize(sourceSection);
+      }
+    }
+
+    /**
+     * Creates a SOM number literal from the given string.
+     */
+    public ExpressionNode number(final double value, final SourceSection sourceSection) {
+      return new DoubleLiteralNode(value).initialize(sourceSection);
+    }
 
     /**
      * Creates a SOM string literal from the given string.

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -38,10 +38,12 @@ import com.google.gson.JsonElement;
 import com.oracle.truffle.api.source.SourceSection;
 import com.sun.java.accessibility.util.Translator;
 
+import som.compiler.MethodBuilder.MethodDefinitionError;
 import som.compiler.MixinBuilder.MixinDefinitionError;
 import som.interpreter.SNodeFactory;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.literals.ArrayLiteralNode;
 import som.interpreter.nodes.literals.BooleanLiteralNode.FalseLiteralNode;
 import som.interpreter.nodes.literals.BooleanLiteralNode.TrueLiteralNode;
 import som.interpreter.nodes.literals.DoubleLiteralNode;
@@ -180,7 +182,79 @@ public class AstBuilder {
     }
 
     /**
-     * Adds a method with the given selector, parameters, and body to the object at the top of
+     * Adds a block with the given variables and body to the method at the top of the stack.
+     *
+     * Blocks use a special signatures in the form of:
+     *
+     * <method name>λ<line>@<column><argument tag>
+     *
+     * where the argument tag contains exactly one `:` for each of the blocks arguments
+     * (excluding the implicit self). For this reason it is necessary to replace any `:` in the
+     * method name with something else (in this case, `_` is used).
+     *
+     * As an example, a two-argument block declared at line=5, column=8 in the method `#foo::`
+     * has the signature:
+     *
+     * #foo__λ5@8::
+     */
+    public ExpressionNode block(final SSymbol[] parameters, final SSymbol[] locals,
+        final JsonArray body, final SourceSection sourceSection) {
+
+      // Generate the signature for the block
+      int line = sourceSection.getStartLine();
+      int column = sourceSection.getStartColumn();
+      String methodName = scopeManager.peekMethod().getSignature().getString();
+      String suffix = line + "@" + column;
+      for (int i = 0; i < parameters.length; i++) {
+        suffix += ":";
+      }
+      SSymbol signature = symbolFor(methodName.replace(":", "_") + "λ" + suffix);
+
+      // Create the new block
+      MethodBuilder builder = scopeManager.newBlock(signature);
+
+      // Set the parameters
+      builder.addArgument(Symbols.BLOCK_SELF, sourceManager.empty());
+      for (int i = 0; i < parameters.length; i++) {
+        builder.addArgument(parameters[i], sourceManager.empty());
+      }
+
+      // Set the locals
+      for (int i = 0; i < locals.length; i++) {
+        try {
+          builder.addLocal(locals[i], false, sourceManager.empty());
+        } catch (MethodDefinitionError e) {
+          language.getVM().errorExit("Failed to add " + locals[i] + " to "
+              + builder.getSignature() + ": " + e.getMessage());
+        }
+      }
+
+      builder.setVarsOnMethodScope();
+      builder.finalizeMethodScope();
+
+      // Translate the body and add each to the initializer
+      List<ExpressionNode> expressions = new ArrayList<ExpressionNode>();
+      for (JsonElement element : body) {
+        Object expr = translator.translate(element.getAsJsonObject());
+        if (expr != null) {
+          if (expr instanceof ExpressionNode) {
+            expressions.add((ExpressionNode) expr);
+          } else {
+            language.getVM().errorExit(
+                "Only expression nodes can be provided for the body of an object's initializer");
+            throw new RuntimeException();
+          }
+        }
+      }
+
+      // Assemble and return the completed block
+      return scopeManager.assembleCurrentBlock(
+          SNodeFactory.createSequence(expressions, sourceManager.empty()),
+          sourceSection);
+    }
+
+    /**
+     * Adds a method with the given selector, variables, and body to the object at the top of
      * the stack.
      */
     public void method(final SSymbol selector, final SSymbol[] parameters,
@@ -222,11 +296,38 @@ public class AstBuilder {
     /**
      * Sends the named message send to the given receiver, with the given arguments. Note that
      * the receiver is added as the first argument of the message send.
+     *
+     * Note that the selector may be changed in some cases, for example Grace's blocks define
+     * an "apply" method that maps directly onto Newspeak's "value" method. We choose to
+     * translate these signatures directly rather than attach new methods to the SOM
+     * objects.
      */
     public ExpressionNode explicit(final SSymbol selector, final ExpressionNode receiver,
         final List<ExpressionNode> arguments, final SourceSection sourceSection) {
       arguments.add(0, receiver);
-      return SNodeFactory.createMessageSend(selector, arguments, sourceSection,
+      SSymbol selectorAfterChecks = selector;
+
+      // Use the Newspeak's `value` methods directly when the selector is Grace's `apply`
+      if (selector.getString().equals("apply")) {
+        selectorAfterChecks = symbolFor("value");
+      } else if (selector.getString().equals("apply:")) {
+        selectorAfterChecks = symbolFor("value:");
+      } else if (selector.getString().equals("apply::")) {
+        selectorAfterChecks = symbolFor("value:with:");
+      } else if (selector.getString().contains("apply:::")) {
+
+        // For the variable arity method, we need to provide the arguments as a list instead.
+        int n = arguments.size() - 1;
+        selectorAfterChecks = symbolFor("valueWithArguments:");
+        List<ExpressionNode> newArguments = new ArrayList<ExpressionNode>();
+        newArguments.add(
+            ArrayLiteralNode.create(
+                arguments.subList(1, arguments.size()).toArray(new ExpressionNode[n - 1]),
+                sourceSection));
+        return explicit(selectorAfterChecks, arguments.get(0), newArguments, sourceSection);
+      }
+
+      return SNodeFactory.createMessageSend(selectorAfterChecks, arguments, sourceSection,
           language.getVM());
     }
 

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -245,6 +245,7 @@ public class AstBuilder {
         return implicit(selector, sourceSection);
       } else {
         MethodBuilder method = scopeManager.peekMethod();
+        arguments.add(0, method.getSelfRead(sourceSection));
         return SNodeFactory.createImplicitReceiverSend(selector,
             arguments.toArray(new ExpressionNode[arguments.size()]), method.getScope(),
             method.getMixin().getMixinId(), sourceSection, language.getVM());

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -138,7 +138,11 @@ public class JsonTreeTranslator {
       return translate(node.get("value").getAsJsonObject());
 
     } else if (nodeType(node).equals("var-declaration")) {
-      return translate(node.get("value").getAsJsonObject());
+      if (node.get("value").isJsonNull()) {
+        return null;
+      } else {
+        return translate(node.get("value").getAsJsonObject());
+      }
 
     } else {
       language.getVM().errorExit(

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -128,7 +128,10 @@ public class JsonTreeTranslator {
    * depends on the type node.
    */
   private Object value(final JsonObject node) {
-    if (nodeType(node).equals("string-literal")) {
+    if (nodeType(node).equals("number")) {
+      return Double.parseDouble(node.get("digits").getAsString());
+
+    } else if (nodeType(node).equals("string-literal")) {
       return node.get("raw").getAsString();
 
     } else {
@@ -339,6 +342,9 @@ public class JsonTreeTranslator {
       astBuilder.objectBuilder.addImmutableSlot(symbolFor(name(node)), importExpression,
           source(node));
       return null;
+
+    } else if (nodeType(node).equals("number")) {
+      return astBuilder.literalBuilder.number((double) value(node), source(node));
 
     } else if (nodeType(node).equals("string-literal")) {
       return astBuilder.literalBuilder.string((String) value(node), source(node));

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -111,6 +111,19 @@ public class JsonTreeTranslator {
   }
 
   /**
+   * Gets the value of the path field in a {@link JsonObject}
+   */
+  private String path(final JsonObject node) {
+    if (node.get("path").isJsonObject()) {
+      return node.get("path").getAsJsonObject().get("raw").getAsString();
+    } else {
+      language.getVM().errorExit(
+          "The translator doesn't understand how to get a path from " + nodeType(node));
+      throw new RuntimeException();
+    }
+  }
+
+  /**
    * Extracts a literal value from the {@link JsonObject}. The field containing the value
    * depends on the type node.
    */
@@ -319,6 +332,13 @@ public class JsonTreeTranslator {
 
     } else if (nodeType(node).equals("explicit-receiver-request")) {
       return explicit(selector(node), receiver(node), arguments(node), source(node));
+
+    } else if (nodeType(node).equals("import")) {
+      ExpressionNode importExpression =
+          astBuilder.requestBuilder.importModule(symbolFor(path(node)));
+      astBuilder.objectBuilder.addImmutableSlot(symbolFor(name(node)), importExpression,
+          source(node));
+      return null;
 
     } else if (nodeType(node).equals("string-literal")) {
       return astBuilder.literalBuilder.string((String) value(node), source(node));

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -376,7 +376,10 @@ public class JsonTreeTranslator {
    */
   public Object translate(final JsonObject node) {
 
-    if (nodeType(node).equals("method-declaration")) {
+    if (nodeType(node).equals("comment")) {
+      return null;
+
+    } else if (nodeType(node).equals("method-declaration")) {
       astBuilder.objectBuilder.method(selector(node), parameters(node), locals(node),
           body(node));
       return null;

--- a/src/som/compiler/KernanClient.java
+++ b/src/som/compiler/KernanClient.java
@@ -159,7 +159,7 @@ public class KernanClient {
     }
 
     private void setMessage(final String message) {
-      if (data.length < 126) {
+      if (message.length() < 126) {
         setMessageWithLenLessThan126(message);
       } else {
         setMessageWithLenGreaterThanOrEqual126(message);


### PR DESCRIPTION
Here I've extended both the `JsonTreeTranslator` and the `AstBuilder` to enable many more of Grace's features to be translated. In particular, the following Grace expressions are now supported:

- module imports
- number and boolean literals (string literals were already supported)
- variable artiy blocks
- definitions and variables
-  operator and assignment requests 
- comments

Note that assignment is referred to as bind for consistency with the parse tree and also that while comment nodes are translated nothing is done with them.  

The more interesting changes made here are the handling of variable and definition declarations and the processing of requests to the variable arity `apply` method of blocks. 

### Processing Variables and Definitions

In terms of variable and definition declarations, the body of a module, method, or block is scanned to find any local declarations. The name of any local declarations are recorded and then used when building the corresponding module, method, or block; each local is installed as a mutable local that will be initially assigned SOM's `nil`. Consequently, when the node for the local declaration is later translated, by the `JsonTreeVisitor`, it can simply be processed as an assignment request.

### Dealing with `apply`

The `apply` method defined for Grace's blocks maps directly onto the `value` method defined for Newspeak's blocks. Consequently, we can simply change the selector of implicit message requests from these apply methods from `apply` to `value`. 

### Other changes

The other changes include two bug fixes that (1) correct an issue with setting the frame size incorrectly (`KernanClient`) and (2) add a missing self-read from the construction of implicit message sends (`AstBuilder`).