### PR TITLE
Testing and more upgrades

### DIFF
--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -608,6 +608,18 @@ public class AstBuilder {
       return explicit(Symbols.LOAD_SINGLETON_MODULE, platformModule(), args,
           sourceManager.empty());
     }
+
+    /**
+     * Creates an expression to return the given expression from a block, which stops any
+     * further expressions in the enclosing method from being expected.
+     */
+    public ExpressionNode makeBlockReturn(final ExpressionNode returnExpression,
+        final SourceSection sourceSection) {
+      assert scopeManager.peekMethod()
+                         .isBlockMethod() : "can only build a return expression for block nodes";
+      return scopeManager.peekMethod().getNonLocalReturn(returnExpression)
+                         .initialize(sourceSection);
+    }
   }
 
   public class Literals {

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -36,7 +36,6 @@ import java.util.List;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.oracle.truffle.api.source.SourceSection;
-import com.sun.java.accessibility.util.Translator;
 
 import som.compiler.MethodBuilder.MethodDefinitionError;
 import som.compiler.MixinBuilder.MixinDefinitionError;
@@ -125,8 +124,8 @@ public class AstBuilder {
      *
      * First the {@link MixinBuilder} is created. We then create the primary "factory", which
      * is a method on the module used to create instances of that module. We use the
-     * {@link Translator} to translate each of the Grace AST nodes into expressions, which are
-     * added to this initializer method.
+     * {@link JsonTreeTranslator} to translate each of the Grace AST nodes into expressions,
+     * which are added to this initializer method.
      *
      * And finally, we create a main method that simply returns zero (via the
      * {@link MethodBuilder} class).

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -74,12 +74,13 @@ public class AstBuilder {
   public final Requests requestBuilder;
   public final Literals literalBuilder;
 
-  public AstBuilder(final JsonTreeTranslator translator, final SourceManager sourceManager,
-      final SomLanguage language, final StructuralProbe probe) {
+  public AstBuilder(final JsonTreeTranslator translator, final ScopeManager scopeManager,
+      final SourceManager sourceManager, final SomLanguage language,
+      final StructuralProbe probe) {
     this.translator = translator;
     this.language = language;
 
-    scopeManager = new ScopeManager(language, probe);
+    this.scopeManager = scopeManager;
     this.sourceManager = sourceManager;
 
     objectBuilder = new Objects();

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -56,6 +56,8 @@ import tools.language.StructuralProbe;
  */
 public class JsonTreeTranslator {
 
+  public static boolean translatingMain = true; // The main module is always translated first
+
   private final SomLanguage language;
 
   private final SourceManager sourceManager;
@@ -438,9 +440,17 @@ public class JsonTreeTranslator {
 
   /**
    * The entry point for the translator, which begins the translation at the module level.
+   *
+   * The body of the module will be added to the initialization method for all modules expect
+   * the main module, in which case those expressions are added to main (so that the system
+   * arguments are available).
    */
   public MixinDefinition translateModule() {
     JsonObject moduleNode = jsonAST.get("module").getAsJsonObject();
-    return astBuilder.objectBuilder.module(locals(moduleNode), body(moduleNode));
+    MixinDefinition result =
+        astBuilder.objectBuilder.module(locals(moduleNode), body(moduleNode),
+            translatingMain);
+    translatingMain = false;
+    return result;
   }
 }

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -60,6 +60,7 @@ public class JsonTreeTranslator {
 
   private final SomLanguage language;
 
+  private final ScopeManager  scopeManager;
   private final SourceManager sourceManager;
 
   private final AstBuilder astBuilder;
@@ -69,9 +70,10 @@ public class JsonTreeTranslator {
       final SomLanguage language, final StructuralProbe probe) {
     this.language = language;
 
+    this.scopeManager = new ScopeManager(language, probe);
     this.sourceManager = new SourceManager(source);
 
-    this.astBuilder = new AstBuilder(this, sourceManager, language, probe);
+    this.astBuilder = new AstBuilder(this, scopeManager, sourceManager, language, probe);
     this.jsonAST = jsonAST;
   }
 

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -222,6 +222,10 @@ public class JsonTreeTranslator {
 
   /**
    * Gets the selector for an array of parts, given either from a request or a declaration.
+   *
+   * Note that signatures defined for Grace's built in objects map directly onto other defined
+   * for SOM's built in objects. We change to the SOM signature in the cases to take advantage
+   * of this mapping.
    */
   private SSymbol selector(final JsonObject node) {
     if (node.has("parts")) {
@@ -232,7 +236,11 @@ public class JsonTreeTranslator {
           node.get("signature").getAsJsonObject().get("parts").getAsJsonArray());
 
     } else if (node.has("operator")) {
-      return symbolFor(node.get("operator").getAsString());
+      String operator = node.get("operator").getAsString();
+      if (operator.equals("!=")) {
+        operator = "<>";
+      }
+      return symbolFor(operator);
 
     } else {
       language.getVM().errorExit(

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -462,6 +462,15 @@ public class JsonTreeTranslator {
     } else if (nodeType(node).equals("operator")) {
       return explicit(selector(node), receiver(node), arguments(node), source(node));
 
+    } else if (nodeType(node).equals("return")) {
+      ExpressionNode returnExpression =
+          (ExpressionNode) translate(node.get("returnvalue").getAsJsonObject());
+      if (scopeManager.peekMethod().isBlockMethod()) {
+        return astBuilder.requestBuilder.makeBlockReturn(returnExpression, source(node));
+      } else {
+        return returnExpression;
+      }
+
     } else if (nodeType(node).equals("inherits")) {
       astBuilder.objectBuilder.setInheritanceByName(className(node), arguments(node),
           source(node));

--- a/src/som/compiler/SourceManager.java
+++ b/src/som/compiler/SourceManager.java
@@ -28,7 +28,9 @@
  */
 package som.compiler;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
@@ -80,9 +82,18 @@ public class SourceManager {
    * @param moduleName
    * @return
    */
+
+  private final static List<String> builtinModules = new ArrayList<String>();
+  static {
+    builtinModules.add("standardGrace");
+    builtinModules.add("io");
+    builtinModules.add("mirrors");
+  }
+
   public String pathForModuleNamed(final SSymbol moduleName) {
-    if (moduleName.getString().equals("standardGrace")) {
-      return System.getenv("MOTH_HOME") + "/GraceLibrary/Modules/standardGrace.grace";
+    if (builtinModules.contains(moduleName.getString())) {
+      return System.getenv("MOTH_HOME") + "/GraceLibrary/Modules/" + moduleName.getString()
+          + ".grace";
     }
     String[] pathParts = source.getPath().split("/");
     String[] pathPartsWithoutFilename = Arrays.copyOfRange(pathParts, 0, pathParts.length - 1);


### PR DESCRIPTION
Here I've upgraded Moth to support Grace's object constructors, classes, and inheritance (to a first approximation) and introduced support for the [new test runner](https://github.com/richard-roberts/GraceLibrary/commit/665ea8cc5b8933110ebac758e934cdf6b12fb9d4). The changes and a few issues are discussed under the headings below.

### Classes and `inherit`

I've extended the `JsonTreeTranslator` and the `AstBuilder` class to support Grace's class declarations and its `inherit` statement. Class declarations are translated into two different units: 

- a SOM class containing the body of the Grace class, and
- a method that returns an instance of that SOM class. 

The method has the name of the Grace-level class, while the SOM class has a munged name. This design is useful because it does not require changing SOMns and also provides support for simple inheritance; the `inherit` expression can be translated to reference the SOM-level class. 

The drawback of this design is that it does not comply with Grace's "Black Equivalency" - a Grace class is nothing more than a method that returns an object constructor. In particular, variables defined in the scope surrounding the Grace class are not available to instances of that class. For the same reason, requests to those variables cannot be used in the inheritance statement; SOMns creates an anonymous method, added to the enclosing class, that is responsible for obtaining an instance of the superclass [(see here)](https://github.com/richard-roberts/SOMns/blob/release/src/som/compiler/MixinBuilder.java#L486). 

In the future, I will change the way inheritance is supported by our fork of SOMns to enable more expressive inheritance expressions. Note that to avoid unexpected errors the current implementation only allows literal arguments for `inherit` expressions.


### Testing 

I've also made changes that support the [new test runner](https://github.com/richard-roberts/GraceLibrary/commit/665ea8cc5b8933110ebac758e934cdf6b12fb9d4), which requires recognizing Grace's built-in "io" and "mirrors" modules and a change to the translator (expressions for the main module need to added to its `#main:` method rather than its initialization method, so that the `args` parameter can be accessed).

With this support, [continuous integration](http://travis-ci.org/richard-roberts/Moth/) has been enabled for [https://github.com/richard-roberts/Moth].


### Other changes

A few bug fixes have been made: the missing reference to `ScopeManager` has been added (`JsonTreeTranslator`); an invalid link in the documentation has been fixed (`JsonTreeTranslator`); and the logic used to set the message length in web-socket frames has been corrected (`KernanClient`).

Finally, Grace's return expressions are now supported, which terminate the current method when used within a block and are ignored otherwise.