### PR TITLE
More translation, operation mappings, and client stability

### DIFF
--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -51,6 +51,7 @@ import som.interpreter.nodes.literals.BooleanLiteralNode.TrueLiteralNode;
 import som.interpreter.nodes.literals.DoubleLiteralNode;
 import som.interpreter.nodes.literals.IntegerLiteralNode;
 import som.interpreter.nodes.literals.LiteralNode;
+import som.interpreter.nodes.literals.NilLiteralNode;
 import som.interpreter.nodes.literals.StringLiteralNode;
 import som.vm.Symbols;
 import som.vmobjects.SSymbol;
@@ -574,6 +575,8 @@ public class AstBuilder {
     public ExpressionNode implicit(final SSymbol name, final SourceSection sourceSection) {
       if (name.getString().equals("true") || name.getString().equals("false")) {
         return literalBuilder.bool(name.getString(), sourceSection);
+      } else if (name.getString().equals("Done")) {
+        return literalBuilder.done(sourceSection);
       }
       MethodBuilder method = scopeManager.peekMethod();
       return method.getImplicitReceiverSend(name, sourceSection);
@@ -655,6 +658,10 @@ public class AstBuilder {
       } else {
         return new FalseLiteralNode().initialize(sourceSection);
       }
+    }
+
+    public ExpressionNode done(final SourceSection sourceSection) {
+      return new NilLiteralNode().initialize(sourceSection);
     }
 
     /**

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -271,6 +271,8 @@ public class JsonTreeTranslator {
       String operator = node.get("operator").getAsString();
       if (operator.equals("!=")) {
         operator = "<>";
+      } else if (operator.equals("==")) {
+        operator = "=";
       }
       return symbolFor(operator);
 

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -257,6 +257,16 @@ public class JsonTreeTranslator {
       return selectorFromParts(
           node.get("signature").getAsJsonObject().get("parts").getAsJsonArray());
 
+    } else if (nodeType(node).equals("prefix-operator")) {
+      String operator = name(node);
+      if (operator.equals("!")) {
+        return symbolFor("not");
+      } else {
+        language.getVM().errorExit("The translator doesn't understand what to do with the `"
+            + operator + "` prefix operator");
+        throw new RuntimeException();
+      }
+
     } else if (node.has("operator")) {
       String operator = node.get("operator").getAsString();
       if (operator.equals("!=")) {
@@ -463,6 +473,9 @@ public class JsonTreeTranslator {
 
     } else if (nodeType(node).equals("operator")) {
       return explicit(selector(node), receiver(node), arguments(node), source(node));
+
+    } else if (nodeType(node).equals("prefix-operator")) {
+      return explicit(selector(node), receiver(node), new JsonObject[] {}, source(node));
 
     } else if (nodeType(node).equals("parenthesised")) {
       return translate(node.get("expression").getAsJsonObject());

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -464,6 +464,9 @@ public class JsonTreeTranslator {
     } else if (nodeType(node).equals("operator")) {
       return explicit(selector(node), receiver(node), arguments(node), source(node));
 
+    } else if (nodeType(node).equals("parenthesised")) {
+      return translate(node.get("expression").getAsJsonObject());
+
     } else if (nodeType(node).equals("return")) {
       ExpressionNode returnExpression =
           (ExpressionNode) translate(node.get("returnvalue").getAsJsonObject());

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -273,6 +273,8 @@ public class JsonTreeTranslator {
         operator = "<>";
       } else if (operator.equals("==")) {
         operator = "=";
+      } else if (operator.equals("/")) {
+        operator = "//";
       }
       return symbolFor(operator);
 

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -446,6 +446,9 @@ public class JsonTreeTranslator {
       astBuilder.objectBuilder.clazzMethod(selector, parameters, source(node));
       return null;
 
+    } else if (nodeType(node).equals("object")) {
+      return astBuilder.objectBuilder.objectConstructor(locals(node), body(node), source(node));
+
     } else if (nodeType(node).equals("block")) {
       return astBuilder.objectBuilder.block(parameters(node), locals(node), body(node),
           source(node));

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -81,7 +81,7 @@ public class JsonTreeTranslator {
    * Uses the {@link SourceManager} to create a section corresponding to the source code at the
    * given line and column.
    */
-  private SourceSection source(final JsonObject node) {
+  public SourceSection source(final JsonObject node) {
     int line = node.get("line").getAsInt();
     int column = node.get("column").getAsInt();
     return sourceManager.atLineColumn(line, column);
@@ -447,7 +447,8 @@ public class JsonTreeTranslator {
       return null;
 
     } else if (nodeType(node).equals("object")) {
-      return astBuilder.objectBuilder.objectConstructor(locals(node), body(node), source(node));
+      return astBuilder.objectBuilder.objectConstructor(locals(node), body(node),
+          source(node));
 
     } else if (nodeType(node).equals("block")) {
       return astBuilder.objectBuilder.block(parameters(node), locals(node), body(node),
@@ -513,6 +514,9 @@ public class JsonTreeTranslator {
 
     } else if (nodeType(node).equals("string-literal")) {
       return astBuilder.literalBuilder.string((String) value(node), source(node));
+
+    } else if (nodeType(node).equals("interpolated-string")) {
+      return astBuilder.requestBuilder.interpolatedString(node.get("parts").getAsJsonArray());
 
     } else {
       language.getVM().errorExit(

--- a/src/som/compiler/KernanClient.java
+++ b/src/som/compiler/KernanClient.java
@@ -290,6 +290,18 @@ public class KernanClient {
     }
 
     /**
+     * Reads enough bytes from the stream to compose an long (who cares if it's signed).
+     */
+    private long readLengthGreaterThan65535() {
+      try {
+        return stream.readLong();
+      } catch (IOException e) {
+        vm.errorExit("Websocket failed to read short:" + e.getMessage());
+        throw new RuntimeException();
+      }
+    }
+
+    /**
      * This method examines the structure of the given message to decide whether or not it
      * contains a parse tree.
      *
@@ -334,9 +346,11 @@ public class KernanClient {
       int op = (opByte + 128);
 
       // Get the length of the message
-      int len = lenByte;
+      long len = lenByte;
       if (len == 126) {
         len = readLengthGreaterThan126();
+      } else if (len == 127) {
+        len = readLengthGreaterThan65535();
       }
 
       // And parse the message itself

--- a/src/som/compiler/ScopeManager.java
+++ b/src/som/compiler/ScopeManager.java
@@ -207,10 +207,11 @@ public class ScopeManager {
    * Produces a finished class definition by assembling the object at the top of the stack, and
    * then adds the resulting class to the object enclosing it (the object below it in the
    * stack).
-   * 
+   *
    * @throws MixinDefinitionError
+   * @return - the assembled class definition
    */
-  public void assumbleCurrentClazz(final SourceSection sourceSection) {
+  public MixinDefinition assumbleCurrentClazz(final SourceSection sourceSection) {
     MixinDefinition result = popObject().assemble(sourceSection);
     try {
       peekObject().addNestedMixin(result);
@@ -219,6 +220,8 @@ public class ScopeManager {
           "Failed to add " + result.getName() + " to " + peekObject().getName());
       throw new RuntimeException();
     }
+
+    return result;
   }
 
   /**

--- a/src/som/compiler/SourcecodeCompiler.java
+++ b/src/som/compiler/SourcecodeCompiler.java
@@ -84,7 +84,11 @@ public class SourcecodeCompiler {
 
     } else if (response.has("mode")
         && response.get("mode").getAsString().equals("static-error")) {
-      language.getVM().errorExit("Kernan Error: " + response.get("message").getAsString());
+      String errorMessage = "Kernan Error: " + response.get("message").getAsString();
+      if (response.has("line")) {
+        errorMessage += " (@ line " + response.get("line").getAsInt() + ")";
+      }
+      language.getVM().errorExit(errorMessage);
       throw new RuntimeException();
 
     } else {


### PR DESCRIPTION
Here I've extended the `JsonTreeTranslator` and the `AstBuilder` to support Grace's parentheses and object constructors and string interpolation. The parentheses work as one would expect. String interpolation is translated as a concatenation of the elements (with `asString` invoked on each element). The support for object literals is more complex (explained below). 

I've also made a few service changes:

- the KernanClient is now more stable (the client successively receives messages >65335 characters),
- the compiler prints line numbers in parsing errors received from Kernan
- Grace's `Done` is now understood (mapped to SOM's `nil`
- more of Grace's operators have been translated:`!`, `==`, and `/`

### Translation for Object Constructors

SOM is class-based and, consequently, the translator needs to generate a class that can be used to create this object. To do so, the `JsonTreeTranslator` first extracts the body of the object constructor and then asks the `AstBuilder` to create define an anonymous class (the class implements the body of the object). Finally, the `AstBuilder` returns a SOM `ObjectLiteral` that, when executed, creates and returns the object.