### PR TITLE
Support for Boyland type-checking

### DIFF
--- a/som
+++ b/som
@@ -124,6 +124,9 @@ parser.add_argument('-D', help="define a Java property",
 parser.add_argument('-ac', '--ansi-coloring', help='Enable ANSI coloring for output from interpreter with true, or disable with false',
                     dest='use_ansi_coloring', action='store', default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty())
 
+parser.add_argument('-bc', '--boyland-checking', help='Turns on Boyland type checks',
+                    dest='boyland_checking', action='store_true', default=False)
+
 parser.add_argument('args', nargs=argparse.REMAINDER,
                     help='arguments passed to SOMns')
 
@@ -238,6 +241,9 @@ if args.som_dnu:
 
 if args.use_ansi_coloring:
     flags += ['-Dsom.useAnsiColoring=' + str(args.use_ansi_coloring).lower()]
+
+if args.boyland_checking:
+    flags += ['-Dsom.boylandChecking=' + str(args.boyland_checking).lower()]
 
 # Handle executable names
 if sys.argv[0].endswith('fast'):

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -383,7 +383,7 @@ public class AstBuilder {
       // Create the initialization method
       MethodBuilder instanceFactory = builder.getPrimaryFactoryMethodBuilder();
       instanceFactory.setSignature(Symbols.NEW);
-      instanceFactory.addArgument(Symbols.SELF, sourceManager.empty());
+      instanceFactory.addUntypedArgument(Symbols.SELF, sourceManager.empty());
       builder.setupInitializerBasedOnPrimaryFactory(sourceManager.empty());
       builder.setInitializerSource(sourceManager.empty());
       builder.finalizeInitializer();
@@ -543,13 +543,14 @@ public class AstBuilder {
      * the stack.
      */
     public void method(final SSymbol selector, final SSymbol[] parameters,
-        final SSymbol[] locals, final JsonArray body) {
+        final SSymbol[] types, final SSymbol[] locals, final JsonArray body) {
       MethodBuilder builder = scopeManager.newMethod(selector);
 
       // Set the parameters
-      builder.addArgument(Symbols.SELF, sourceManager.empty());
+      builder.addUntypedArgument(Symbols.SELF, sourceManager.empty());
       for (int i = 0; i < parameters.length; i++) {
-        builder.addArgument(parameters[i], sourceManager.empty());
+        builder.addTypedArgument(parameters[i], typeManager.get(types[i]),
+            sourceManager.empty());
       }
 
       // Set the locals

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -74,19 +74,22 @@ public class AstBuilder {
 
   private final ScopeManager  scopeManager;
   private final SourceManager sourceManager;
+  private final TypeManager   typeManager;
 
   public final Objects  objectBuilder;
   public final Requests requestBuilder;
   public final Literals literalBuilder;
 
   public AstBuilder(final JsonTreeTranslator translator, final ScopeManager scopeManager,
-      final SourceManager sourceManager, final SomLanguage language,
+      final SourceManager sourceManager, final TypeManager typeManager,
+      final SomLanguage language,
       final StructuralProbe probe) {
     this.translator = translator;
     this.language = language;
 
     this.scopeManager = scopeManager;
     this.sourceManager = sourceManager;
+    this.typeManager = typeManager;
 
     objectBuilder = new Objects();
     requestBuilder = new Requests();
@@ -152,8 +155,8 @@ public class AstBuilder {
       // Set up the method used to create instances
       MethodBuilder instanceFactory = moduleBuilder.getPrimaryFactoryMethodBuilder();
       instanceFactory.setSignature(Symbols.DEFAULT_MODULE_FACTORY);
-      instanceFactory.addArgument(Symbols.SELF, sourceManager.empty());
-      instanceFactory.addArgument(Symbols.PLATFORM_MODULE, sourceManager.empty());
+      instanceFactory.addUntypedArgument(Symbols.SELF, sourceManager.empty());
+      instanceFactory.addUntypedArgument(Symbols.PLATFORM_MODULE, sourceManager.empty());
       moduleBuilder.setupInitializerBasedOnPrimaryFactory(sourceManager.empty());
       moduleBuilder.setInitializerSource(sourceManager.empty());
       moduleBuilder.finalizeInitializer();
@@ -205,8 +208,8 @@ public class AstBuilder {
       // Create the main method, which contains the main module expressions. If this is not the
       // main module then this method simply returns zero
       MethodBuilder mainMethod = scopeManager.newMethod(Symbols.DEFAULT_MAIN_METHOD);
-      mainMethod.addArgument(Symbols.SELF, sourceManager.empty());
-      mainMethod.addArgument(Symbols.MAIN_METHOD_ARGS, sourceManager.empty());
+      mainMethod.addUntypedArgument(Symbols.SELF, sourceManager.empty());
+      mainMethod.addUntypedArgument(Symbols.MAIN_METHOD_ARGS, sourceManager.empty());
       mainMethod.setVarsOnMethodScope();
       mainMethod.finalizeMethodScope();
       List<ExpressionNode> expressions = new ArrayList<ExpressionNode>();
@@ -260,9 +263,9 @@ public class AstBuilder {
       // Create the initialization method, with munging applied to the argument names
       MethodBuilder instanceFactory = builder.getPrimaryFactoryMethodBuilder();
       instanceFactory.setSignature(symbolFor(instanceFactoryName));
-      instanceFactory.addArgument(Symbols.SELF, sourceManager.empty());
+      instanceFactory.addUntypedArgument(Symbols.SELF, sourceManager.empty());
       for (int i = 0; i < parameters.length; i++) {
-        instanceFactory.addArgument(symbolFor(parameters[i].getString() + "'"),
+        instanceFactory.addUntypedArgument(symbolFor(parameters[i].getString() + "'"),
             sourceManager.empty());
       }
       builder.setupInitializerBasedOnPrimaryFactory(sourceManager.empty());
@@ -318,9 +321,9 @@ public class AstBuilder {
       MethodBuilder builder = scopeManager.newMethod(name);
 
       // Set the parameters
-      builder.addArgument(Symbols.SELF, sourceManager.empty());
+      builder.addUntypedArgument(Symbols.SELF, sourceManager.empty());
       for (int i = 0; i < parameters.length; i++) {
-        builder.addArgument(parameters[i], sourceManager.empty());
+        builder.addUntypedArgument(parameters[i], sourceManager.empty());
       }
 
       builder.setVarsOnMethodScope();
@@ -496,9 +499,9 @@ public class AstBuilder {
       MethodBuilder builder = scopeManager.newBlock(signature);
 
       // Set the parameters
-      builder.addArgument(Symbols.BLOCK_SELF, sourceManager.empty());
+      builder.addUntypedArgument(Symbols.BLOCK_SELF, sourceManager.empty());
       for (int i = 0; i < parameters.length; i++) {
-        builder.addArgument(parameters[i], sourceManager.empty());
+        builder.addUntypedArgument(parameters[i], sourceManager.empty());
       }
 
       // Set the locals

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -297,7 +297,7 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
     initializer.setSignature(getInitializerName(
         primaryFactoryMethod.getSignature()));
     for (Argument arg : primaryFactoryMethod.getArguments()) {
-      initializer.addArgument(arg.name, arg.source);
+      initializer.addUntypedArgument(arg.name, arg.source);
     }
     initializer.setVarsOnMethodScope();
   }
@@ -493,7 +493,7 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
     }
 
     // self is going to be the enclosing object
-    definitionMethod.addArgument(Symbols.SELF,
+    definitionMethod.addUntypedArgument(Symbols.SELF,
         SomLanguage.getSyntheticSource("self read", "super-class-resolution")
                    .createSection(1));
     definitionMethod.setSignature(Symbols.DEF_CLASS);
@@ -508,7 +508,7 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
    */
   public void addArgumentToSuperClassResolutionBuilder(final SSymbol name,
       final SourceSection sourceSection) {
-    superclassAndMixinResolutionBuilder.addArgument(name, sourceSection);
+    superclassAndMixinResolutionBuilder.addUntypedArgument(name, sourceSection);
     String newSelector = superclassAndMixinResolutionBuilder.getSignature().getString() + ":";
     superclassAndMixinResolutionBuilder.setSignature(symbolFor(newSelector));
   }

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -537,7 +537,7 @@ public final class MixinDefinition {
 
     @Override
     public AbstractDispatchNode getDispatchNode(final Object receiver,
-        final Object firstArg, final AbstractDispatchNode next,
+        final Object[] arguments, final AbstractDispatchNode next,
         final boolean forAtomic) {
       SObject rcvr = (SObject) receiver;
       StorageLocation loc = rcvr.getObjectLayout().getStorageLocation(this);
@@ -608,7 +608,7 @@ public final class MixinDefinition {
 
     @Override
     public AbstractDispatchNode getDispatchNode(final Object receiver,
-        final Object firstArg, final AbstractDispatchNode next, final boolean forAtomic) {
+        final Object[] arguments, final AbstractDispatchNode next, final boolean forAtomic) {
       SObject rcvr = (SObject) receiver;
       StorageLocation loc = rcvr.getObjectLayout().getStorageLocation(mainSlot);
       boolean isSet = loc.isSet(rcvr);
@@ -727,7 +727,7 @@ public final class MixinDefinition {
     SSymbol init = MixinBuilder.getInitializerName(Symbols.NEW);
     MethodBuilder builder = new MethodBuilder(true, initializerBuilder.getLanguage(), null);
     builder.setSignature(init);
-    builder.addArgument(Symbols.SELF,
+    builder.addUntypedArgument(Symbols.SELF,
         SomLanguage.getSyntheticSource("self read", "super-class-resolution")
                    .createSection(1));
 
@@ -773,7 +773,7 @@ public final class MixinDefinition {
     Method adaptedInvokable = originalInvokable.cloneAndAdaptAfterScopeChange(
         adaptedScope, appliesTo + 1, false, true);
     return new SInvokable(invokable.getSignature(), invokable.getAccessModifier(),
-        adaptedInvokable, invokable.getEmbeddedBlocks());
+        adaptedInvokable, invokable.getEmbeddedBlocks(), invokable.getExepctedTypes());
   }
 
   private void adaptFactoryMethods(final MethodScope scope, final int appliesTo) {

--- a/src/som/compiler/NewspeakParser.java
+++ b/src/som/compiler/NewspeakParser.java
@@ -341,7 +341,7 @@ public class NewspeakParser {
       messagePattern(primaryFactory);
     } else {
       // in the standard case, the primary factory method is #new
-      primaryFactory.addArgument(Symbols.SELF, getEmptySource());
+      primaryFactory.addUntypedArgument(Symbols.SELF, getEmptySource());
       primaryFactory.setSignature(Symbols.NEW);
     }
     mxnBuilder.setupInitializerBasedOnPrimaryFactory(getSource(coord));
@@ -854,7 +854,7 @@ public class NewspeakParser {
   }
 
   private void messagePattern(final MethodBuilder builder) throws ParseError {
-    builder.addArgument(Symbols.SELF, getEmptySource());
+    builder.addUntypedArgument(Symbols.SELF, getEmptySource());
     switch (sym) {
       case Identifier:
         unaryPattern(builder);
@@ -884,7 +884,7 @@ public class NewspeakParser {
     builder.addMethodDefinitionSource(getSource(coord));
 
     coord = getCoordinate();
-    builder.addArgument(symbolFor(argument()), getSource(coord));
+    builder.addUntypedArgument(symbolFor(argument()), getSource(coord));
   }
 
   protected void keywordPattern(final MethodBuilder builder) throws ParseError {
@@ -895,7 +895,7 @@ public class NewspeakParser {
       builder.addMethodDefinitionSource(getSource(coord));
 
       coord = getCoordinate();
-      builder.addArgument(symbolFor(argument()), getSource(coord));
+      builder.addUntypedArgument(symbolFor(argument()), getSource(coord));
     } while (sym == Keyword);
 
     builder.setSignature(symbolFor(kw.toString()));
@@ -1629,7 +1629,7 @@ public class NewspeakParser {
 
     // Setup the builder and "new" factory for the implicit class
     MethodBuilder primaryFactory = classBuilder.getPrimaryFactoryMethodBuilder();
-    primaryFactory.addArgument(Symbols.SELF, getEmptySource());
+    primaryFactory.addUntypedArgument(Symbols.SELF, getEmptySource());
     primaryFactory.setSignature(Symbols.NEW);
     classBuilder.setupInitializerBasedOnPrimaryFactory(source);
 
@@ -1683,7 +1683,7 @@ public class NewspeakParser {
     SourceCoordinate coord = getCoordinate();
     expect(NewBlock, DelimiterOpeningTag.class);
 
-    builder.addArgument(Symbols.BLOCK_SELF, getEmptySource());
+    builder.addUntypedArgument(Symbols.BLOCK_SELF, getEmptySource());
 
     if (sym == Colon) {
       blockPattern(builder);
@@ -1717,7 +1717,7 @@ public class NewspeakParser {
     do {
       expect(Colon, KeywordTag.class);
       SourceCoordinate coord = getCoordinate();
-      builder.addArgument(symbolFor(argument()), getSource(coord));
+      builder.addUntypedArgument(symbolFor(argument()), getSource(coord));
     } while (sym == Colon);
   }
 

--- a/src/som/compiler/TypeManager.java
+++ b/src/som/compiler/TypeManager.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.compiler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import som.interpreter.SomLanguage;
+import som.vm.SomStructuralType;
+import som.vmobjects.SSymbol;
+
+
+/**
+ * The Type Manager is simply a place to record and then, later, recall types by their symbolic
+ * names. The types themselves are extracted during translation from Grace AST into SOM AST
+ * builders (@see {@link JsonTreeTranslator}).
+ *
+ * The type manager has the primitive types - named Boolean, Number, and String - built in.
+ *
+ * TODO: Types are currently indexed by their symbolic name. This means that two different
+ * modules may not both introduce the same type. To allow this to happen, we could perhaps
+ * index types first by their module and then by their name?
+ */
+public class TypeManager {
+
+  private final SomLanguage language;
+
+  private final Map<SSymbol, SomStructuralType> types;
+
+  public TypeManager(final SomLanguage language, final SourceManager sourceManager) {
+    this.language = language;
+    types = new HashMap<SSymbol, SomStructuralType>();
+
+    types.put(SomStructuralType.NAME_FOR_BOOLEAN_PRIMITIVE, new SomStructuralType(
+        SomStructuralType.NAME_FOR_BOOLEAN_PRIMITIVE, new ArrayList<SSymbol>()));
+    types.put(SomStructuralType.NAME_FOR_NUMBER_PRIMITIVE, new SomStructuralType(
+        SomStructuralType.NAME_FOR_NUMBER_PRIMITIVE, new ArrayList<SSymbol>()));
+    types.put(SomStructuralType.NAME_FOR_STRING_PRIMITIVE, new SomStructuralType(
+        SomStructuralType.NAME_FOR_STRING_PRIMITIVE, new ArrayList<SSymbol>()));
+  }
+
+  /**
+   * Adds a type, expressed as a name and a list of signatures, to the record.
+   */
+  public void addTypeDeclaration(final SSymbol name, final List<SSymbol> signatures) {
+    SomStructuralType type = new SomStructuralType(name, signatures);
+    types.put(name, type);
+  }
+
+  /**
+   * Returns the type corresponding to the given name, or otherwise errors when that type
+   * doesn't exist.
+   */
+  public SomStructuralType get(final SSymbol name) {
+    if (name.getString().equals("Unknown")) {
+      return null;
+    }
+
+    if (!types.containsKey(name)) {
+      language.getVM().errorExit(
+          "The type manager doesn't understand the type " + name + ". Was it declared?");
+    }
+    return types.get(name);
+  }
+
+}

--- a/src/som/compiler/Variable.java
+++ b/src/som/compiler/Variable.java
@@ -23,6 +23,7 @@ import som.interpreter.nodes.LocalVariableNodeFactory.LocalVariableReadNodeGen;
 import som.interpreter.nodes.LocalVariableNodeFactory.LocalVariableWriteNodeGen;
 import som.interpreter.nodes.NonLocalVariableNodeFactory.NonLocalVariableReadNodeGen;
 import som.interpreter.nodes.NonLocalVariableNodeFactory.NonLocalVariableWriteNodeGen;
+import som.vm.SomStructuralType;
 import som.vm.Symbols;
 import som.vmobjects.SSymbol;
 import tools.SourceCoordinate;
@@ -49,11 +50,13 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     }
   }
 
-  public final SSymbol       name;
-  public final SourceSection source;
+  public final SSymbol           name;
+  public final SomStructuralType type;
+  public final SourceSection     source;
 
-  Variable(final SSymbol name, final SourceSection source) {
+  Variable(final SSymbol name, final SomStructuralType type, final SourceSection source) {
     this.name = name;
+    this.type = type;
     this.source = source;
   }
 
@@ -105,8 +108,9 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   public static final class Argument extends Variable {
     public final int index;
 
-    Argument(final SSymbol name, final int index, final SourceSection source) {
-      super(name, source);
+    Argument(final SSymbol name, final SomStructuralType type, final int index,
+        final SourceSection source) {
+      super(name, type, source);
       this.index = index;
     }
 
@@ -152,7 +156,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
         return null;
       }
 
-      Local l = new ImmutableLocal(name, source);
+      Local l = new ImmutableLocal(name, type, source);
       l.init(descriptor.addFrameSlot(l));
       return l;
     }
@@ -182,8 +186,8 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   public abstract static class Local extends Variable {
     @CompilationFinal private FrameSlot slot;
 
-    Local(final SSymbol name, final SourceSection source) {
-      super(name, source);
+    Local(final SSymbol name, final SomStructuralType type, final SourceSection source) {
+      super(name, type, source);
     }
 
     public void init(final FrameSlot slot) {
@@ -246,13 +250,14 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   }
 
   public static final class MutableLocal extends Local {
-    MutableLocal(final SSymbol name, final SourceSection source) {
-      super(name, source);
+    MutableLocal(final SSymbol name, final SomStructuralType type,
+        final SourceSection source) {
+      super(name, type, source);
     }
 
     @Override
     public Local create() {
-      return new MutableLocal(name, source);
+      return new MutableLocal(name, type, source);
     }
 
     @Override
@@ -262,13 +267,14 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   }
 
   public static final class ImmutableLocal extends Local {
-    ImmutableLocal(final SSymbol name, final SourceSection source) {
-      super(name, source);
+    ImmutableLocal(final SSymbol name, final SomStructuralType type,
+        final SourceSection source) {
+      super(name, type, source);
     }
 
     @Override
     public Local create() {
-      return new ImmutableLocal(name, source);
+      return new ImmutableLocal(name, type, source);
     }
 
     @Override
@@ -286,7 +292,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     @CompilationFinal private FrameSlot slot;
 
     public Internal(final SSymbol name) {
-      super(name, null);
+      super(name, null, null);
     }
 
     public void init(final FrameSlot slot) {

--- a/src/som/interpreter/nodes/dispatch/CachedDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/CachedDispatchNode.java
@@ -12,6 +12,7 @@ import som.VM;
 import som.instrumentation.InstrumentableDirectCallNode;
 import som.vm.VmSettings;
 import som.vm.constants.KernelObj;
+import som.vm.constants.Nil;
 
 
 public final class CachedDispatchNode extends AbstractDispatchNode {
@@ -39,7 +40,7 @@ public final class CachedDispatchNode extends AbstractDispatchNode {
     for (int i = 0; i < guards.length; i++) {
       DispatchGuard guard = guards[i];
       Object arg = arguments[i];
-      boolean matches = guard.entryMatches(arg);
+      boolean matches = arg == Nil.nilObject || guard.entryMatches(arg);
       if (!matches) {
         return false;
       }

--- a/src/som/interpreter/nodes/dispatch/CachedDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/CachedDispatchNode.java
@@ -2,13 +2,16 @@ package som.interpreter.nodes.dispatch;
 
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
 import som.VM;
 import som.instrumentation.InstrumentableDirectCallNode;
 import som.vm.VmSettings;
+import som.vm.constants.KernelObj;
 
 
 public final class CachedDispatchNode extends AbstractDispatchNode {
@@ -16,12 +19,12 @@ public final class CachedDispatchNode extends AbstractDispatchNode {
   @Child private DirectCallNode       cachedMethod;
   @Child private AbstractDispatchNode nextInCache;
 
-  private final DispatchGuard guard;
+  @CompilationFinal(dimensions = 1) private final DispatchGuard[] guards;
 
   public CachedDispatchNode(final CallTarget methodCallTarget,
-      final DispatchGuard guard, final AbstractDispatchNode nextInCache) {
+      final DispatchGuard[] guards, final AbstractDispatchNode nextInCache) {
     super(nextInCache.getSourceSection());
-    this.guard = guard;
+    this.guards = guards;
     this.nextInCache = nextInCache;
     this.cachedMethod = Truffle.getRuntime().createDirectCallNode(methodCallTarget);
     if (VmSettings.DYNAMIC_METRICS) {
@@ -31,10 +34,23 @@ public final class CachedDispatchNode extends AbstractDispatchNode {
     }
   }
 
+  @ExplodeLoop
+  public boolean checkGuards(final Object[] arguments) throws InvalidAssumptionException {
+    for (int i = 0; i < guards.length; i++) {
+      DispatchGuard guard = guards[i];
+      Object arg = arguments[i];
+      boolean matches = guard.entryMatches(arg);
+      if (!matches) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   @Override
   public Object executeDispatch(final Object[] arguments) {
     try {
-      if (guard.entryMatches(arguments[0])) {
+      if (checkGuards(arguments)) {
         return cachedMethod.call(arguments);
       } else {
         return nextInCache.executeDispatch(arguments);
@@ -42,6 +58,9 @@ public final class CachedDispatchNode extends AbstractDispatchNode {
     } catch (InvalidAssumptionException e) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       return replace(nextInCache).executeDispatch(arguments);
+    } catch (IllegalArgumentException e) {
+      KernelObj.signalException("signalArgumentError:", e.getMessage());
+      return null;
     }
   }
 

--- a/src/som/interpreter/nodes/dispatch/DispatchGuard.java
+++ b/src/som/interpreter/nodes/dispatch/DispatchGuard.java
@@ -1,13 +1,17 @@
 package som.interpreter.nodes.dispatch;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
+import som.compiler.MixinDefinition;
 import som.interpreter.objectstorage.ClassFactory;
 import som.interpreter.objectstorage.ObjectLayout;
+import som.vm.SomStructuralType;
 import som.vmobjects.SClass;
 import som.vmobjects.SObject;
 import som.vmobjects.SObject.SImmutableObject;
 import som.vmobjects.SObject.SMutableObject;
+import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 
 
@@ -51,6 +55,34 @@ public abstract class DispatchGuard {
 
     assert obj instanceof SImmutableObject;
     return new CheckSImmutableObject(((SImmutableObject) obj).getObjectLayout());
+  }
+
+  /**
+   * Creates an appropriate type-checking dispatch guard. The expected type may be null (used
+   * for "unknown" types), and in this case we simply create a no-operation type checking
+   * guard. This is done so that every argument always has a corresponding guard, which
+   * simplifies the implementation of the loop used to run these guards against their
+   * arguments. If the guard is a primitive - a boolean, number, or string - we create a
+   * primitive type-checking guard that implements a simple "instance of" check. And finally,
+   * if we are given a proper SOM object, we create a full structural type-checking guard.
+   */
+  public static AbstractTypeCheck createTypeCheck(final SomStructuralType expectedType,
+      final Object argument) {
+    if (expectedType == null) {
+      return new NoTypeCheck();
+    } else if (expectedType.isBoolean()) {
+      return new BooleanTypeCheck();
+    } else if (expectedType.isNumber()) {
+      return new NumberTypeCheck();
+    } else if (expectedType.isString()) {
+      return new StringTypeCheck();
+    } else {
+      return new StructuralTypeCheck(expectedType, argument);
+    }
+  }
+
+  public boolean ignore() {
+    return false;
   }
 
   private static final class CheckClass extends DispatchGuard {
@@ -154,6 +186,112 @@ public abstract class DispatchGuard {
     @Override
     public SObject cast(final Object obj) {
       return (SImmutableObject) obj;
+    }
+  }
+
+  private static abstract class AbstractTypeCheck extends DispatchGuard {
+
+    protected void throwTypeError(final Object obj, final String expected) {
+      throw new IllegalArgumentException(
+          "Argument " + obj + " does not conform to the " + expected + " type");
+    }
+
+  }
+
+  private static final class NoTypeCheck extends AbstractTypeCheck {
+    @Override
+    public boolean entryMatches(final Object obj) throws InvalidAssumptionException {
+      return true;
+    }
+  }
+
+  private static final class BooleanTypeCheck extends AbstractTypeCheck {
+
+    @Override
+    public boolean entryMatches(final Object obj) throws InvalidAssumptionException {
+      if (obj instanceof Boolean) {
+        return true;
+      } else {
+        throwTypeError(obj, "Boolean");
+        return false;
+      }
+    }
+  }
+
+  private static final class NumberTypeCheck extends AbstractTypeCheck {
+
+    @Override
+    public boolean entryMatches(final Object obj) throws InvalidAssumptionException {
+      if (obj instanceof Number) {
+        return true;
+      } else {
+        throwTypeError(obj, "Number");
+        return false;
+      }
+    }
+  }
+
+  private static final class StringTypeCheck extends AbstractTypeCheck {
+
+    @Override
+    public boolean entryMatches(final Object obj) throws InvalidAssumptionException {
+      if (obj instanceof String) {
+        return true;
+      } else {
+        throwTypeError(obj, "String");
+        return false;
+      }
+    }
+
+  }
+
+  /**
+   * This guard is responsible for determining whether the given argument conforms to the given
+   * structural type. Note that the {@link StructuralTypeCheck} is responsible for conducting
+   * the type conformity check itself.
+   *
+   * For efficiency, we perform the structural type check only, during the initialization of
+   * this guard. We cache the result after it has been calculated, indexed by the SClass. For
+   * the next call we simply examine the given argument; if the class is the same then we
+   * assume the result will be the same as was computed previously and simply return true, or
+   * otherwise, we invoke the {@link IllegalArgumentException} error.
+   *
+   * Note that the argument error may be caught by a SOM block and, therefore, we must throw
+   * the error during execution rather than initialization.
+   *
+   */
+  private static final class StructuralTypeCheck extends AbstractTypeCheck {
+
+    private final SomStructuralType structuralType;
+
+    @CompilationFinal private final MixinDefinition expected;
+
+    StructuralTypeCheck(final SomStructuralType structuralType, final Object argument) {
+      this.structuralType = structuralType;
+
+      if (argument instanceof SObjectWithClass && structuralType.matchesObject(argument)) {
+        this.expected = ((SObjectWithClass) argument).getSOMClass().getMixinDefinition();
+      } else {
+        this.expected = null;
+      }
+    }
+
+    @Override
+    public boolean entryMatches(final Object obj)
+        throws InvalidAssumptionException, IllegalArgumentException {
+
+      if (obj instanceof SObjectWithClass
+          && ((SObjectWithClass) obj).getSOMClass().getMixinDefinition() == expected) {
+        return true;
+      } else {
+        throwTypeError(obj, structuralType.getName().getString());
+        return false;
+      }
+    }
+
+    @Override
+    public boolean ignore() {
+      return structuralType == null;
     }
   }
 }

--- a/src/som/interpreter/nodes/dispatch/Dispatchable.java
+++ b/src/som/interpreter/nodes/dispatch/Dispatchable.java
@@ -12,7 +12,7 @@ import som.compiler.AccessModifier;
 public interface Dispatchable {
 
   AbstractDispatchNode getDispatchNode(
-      Object rcvr, Object firstArg, AbstractDispatchNode newChainEnd, boolean forAtomic);
+      Object rcvr, Object[] arguments, AbstractDispatchNode newChainEnd, boolean forAtomic);
 
   AccessModifier getAccessModifier();
 

--- a/src/som/interpreter/nodes/literals/BlockNode.java
+++ b/src/som/interpreter/nodes/literals/BlockNode.java
@@ -11,6 +11,7 @@ import som.compiler.Variable;
 import som.compiler.Variable.Argument;
 import som.interpreter.Method;
 import som.interpreter.nodes.ExpressionNode;
+import som.vm.SomStructuralType;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.debugger.Tags.LiteralTag;
@@ -73,7 +74,7 @@ public class BlockNode extends LiteralNode {
         inliner.outerScopeChanged());
     SInvokable adaptedIvk = new SInvokable(blockMethod.getSignature(),
         AccessModifier.BLOCK_METHOD,
-        adapted, blockMethod.getEmbeddedBlocks());
+        adapted, blockMethod.getEmbeddedBlocks(), new SomStructuralType[] {});
     replace(createNode(adaptedIvk));
   }
 

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -146,7 +146,7 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
         prim.getScope().getFrameDescriptor(),
         (ExpressionNode) primNode.deepCopy(), false, lang);
     return new SInvokable(signature, AccessModifier.PUBLIC,
-        primMethodNode, null);
+        primMethodNode, null, new SomStructuralType[] {});
   }
 
   public EconomicMap<SSymbol, Dispatchable> takeVmMirrorPrimitives() {

--- a/src/som/vm/SomStructuralType.java
+++ b/src/som/vm/SomStructuralType.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2018 Richard Roberts, richard.andrew.roberts@gmail.com
+ * Victoria University of Wellington, Wellington New Zealand
+ * http://gracelang.org/applications/home/
+ *
+ * Copyright (c) 2013 Stefan Marr,     stefan.marr@vub.ac.be
+ * Copyright (c) 2009 Michael Haupt,   michael.haupt@hpi.uni-potsdam.de
+ * Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+ * http://www.hpi.uni-potsdam.de/swa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package som.vm;
+
+import static som.vm.Symbols.symbolFor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.oracle.truffle.api.CompilerAsserts;
+
+import som.interpreter.objectstorage.ClassFactory;
+import som.vmobjects.SClass;
+import som.vmobjects.SInvokable;
+import som.vmobjects.SObjectWithClass;
+import som.vmobjects.SSymbol;
+
+
+/**
+ * This class contains information about a structural type that, at least for now, consists of
+ * a name paired with an array of method names (represented a {@link SSymbol}s).
+ *
+ * With this information, this class can be used to determine whether a given object conforms
+ * to this type. For now, objects conform to the type when they can respond to each of method
+ * names contained in this list.
+ */
+public class SomStructuralType {
+
+  public final static SSymbol NAME_FOR_BOOLEAN_PRIMITIVE = symbolFor("Boolean");
+  public final static SSymbol NAME_FOR_NUMBER_PRIMITIVE  = symbolFor("Number");
+  public final static SSymbol NAME_FOR_STRING_PRIMITIVE  = symbolFor("String");
+
+  private final SSymbol   name;
+  private final SSymbol[] signatures;
+
+  private final Map<ClassFactory, Boolean> matches;
+
+  public SomStructuralType(final SSymbol name, final List<SSymbol> signatures) {
+    this.name = name;
+    this.signatures = signatures.toArray(new SSymbol[signatures.size()]);
+
+    this.matches = new HashMap<ClassFactory, Boolean>();
+  }
+
+  /**
+   * This method computes, and then caches, whether a given object's class conforms to this
+   * type. The calculation is simple: does the class understand each of methods named by
+   * {@link #signatures}?
+   *
+   * The result is indexed against the class of the given object.
+   *
+   * TODO: can we make the indexing more abstract, since multiple classes might implement this
+   * type.
+   */
+  public void computeAndRecordMatch(final Object obj) {
+    CompilerAsserts.neverPartOfCompilation();
+    SClass clazz = ((SObjectWithClass) obj).getSOMClass();
+    for (SSymbol signature : signatures) {
+      if (!clazz.canUnderstand(signature)) {
+        matches.put(((SObjectWithClass) obj).getFactory(), false);
+        return;
+      }
+    }
+    matches.put(((SObjectWithClass) obj).getFactory(), true);
+  }
+
+  /**
+   * This method first obtains the class of the given object. If we've already encountered
+   * this class, we simply return the result we calculated previously. Otherwise, we do the
+   * calculation and store the result.
+   *
+   * Even though each this method is only called via a dispatch guard, the caching is important
+   * (since the same structural type may be referred to by different call sites: @see
+   * {@link SInvokable#getDispatchNode}.
+   *
+   * Finally, note that this method should only be used for checking the conformity of
+   * {@link SObjectWithClass}es.
+   */
+  public boolean matchesObject(final Object obj) {
+    CompilerAsserts.neverPartOfCompilation();
+    ClassFactory factory = ((SObjectWithClass) obj).getFactory();
+    if (matches.containsKey(factory)) {
+      return matches.get(factory);
+    } else {
+      computeAndRecordMatch(obj);
+      return matches.get(factory);
+    }
+  }
+
+  public SSymbol getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return "SomStructuralType[" + name.getString() + "]";
+  }
+
+  public boolean isBoolean() {
+    return getName().equals(NAME_FOR_BOOLEAN_PRIMITIVE);
+  }
+
+  public boolean isNumber() {
+    return getName().equals(NAME_FOR_NUMBER_PRIMITIVE);
+  }
+
+  public boolean isString() {
+    return getName().equals(NAME_FOR_STRING_PRIMITIVE);
+  }
+}

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -33,6 +33,8 @@ public class VmSettings implements Settings {
 
   public static final String INSTRUMENTATION_PROP = "som.instrumentation";
 
+  public static final boolean BOYLAND_CHECKING;
+
   static {
     String prop = System.getProperty("som.threads");
     if (prop == null) {
@@ -73,6 +75,8 @@ public class VmSettings implements Settings {
     IGV_DUMP_AFTER_PARSING = getBool("som.igvDumpAfterParsing", false);
 
     ANSI_COLOR_IN_OUTPUT = getBool("som.useAnsiColoring", false);
+
+    BOYLAND_CHECKING = getBool("som.boylandChecking", false);
   }
 
   private static boolean getBool(final String prop, final boolean defaultVal) {

--- a/src/som/vmobjects/SInvokable.java
+++ b/src/som/vmobjects/SInvokable.java
@@ -46,6 +46,7 @@ import som.interpreter.nodes.dispatch.DispatchGuard;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.interpreter.nodes.dispatch.LexicallyBoundDispatchNode;
 import som.vm.SomStructuralType;
+import som.vm.VmSettings;
 import som.vm.constants.Classes;
 
 
@@ -202,10 +203,14 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
     }
 
     List<DispatchGuard> guards = new ArrayList<DispatchGuard>();
-    guards.add(DispatchGuard.create(rcvr)); // receiver guard
-    for (int i = 0; i < expectedTypes.length; i++) {
-      SomStructuralType expectedType = expectedTypes[i];
-      guards.add(DispatchGuard.createTypeCheck(expectedType, arguments[i + 1]));
+    guards.add(DispatchGuard.create(rcvr)); // receiver guard, always present
+
+    // Add type checking guards when SOMns is in "Boyland Checking" mode
+    if (VmSettings.BOYLAND_CHECKING) {
+      for (int i = 0; i < expectedTypes.length; i++) {
+        SomStructuralType expectedType = expectedTypes[i];
+        guards.add(DispatchGuard.createTypeCheck(expectedType, arguments[i + 1]));
+      }
     }
 
     return new CachedDispatchNode(ct, guards.toArray(new DispatchGuard[guards.size()]), next);

--- a/src/som/vmobjects/SInvokable.java
+++ b/src/som/vmobjects/SInvokable.java
@@ -179,7 +179,7 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
 
   @Override
   public final AbstractDispatchNode getDispatchNode(final Object rcvr,
-      final Object firstArg, final AbstractDispatchNode next, final boolean forAtomic) {
+      final Object[] arguments, final AbstractDispatchNode next, final boolean forAtomic) {
     assert next != null : "Pass the old node, just need the source section";
 
     CallTarget ct = forAtomic ? getAtomicCallTarget() : callTarget;
@@ -189,8 +189,9 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
       return new LexicallyBoundDispatchNode(next.getSourceSection(), ct);
     }
 
-    DispatchGuard guard = DispatchGuard.create(rcvr);
-    return new CachedDispatchNode(ct, guard, next);
+    List<DispatchGuard> guards = new ArrayList<DispatchGuard>();
+    guards.add(DispatchGuard.create(rcvr)); // receiver guard
+    return new CachedDispatchNode(ct, guards.toArray(new DispatchGuard[guards.size()]), next);
   }
 
   @Override


### PR DESCRIPTION
Here I've extended SOMns to support basic verification of type annotations added to parameters in Grace's method declarations. To execute a program with the verification, use the new `--boyland-checking` argument (or `-bc` for short).

During compilation, Grace's type statements are translated into instances of the new `SomStructuralType` class; each instance contains the list of signatures prescribed by the corresponding type statement. When translating a method with type annotations these instances may be accessed, via the new the `TypeManager`, and added as additional information into the `SInvokable` AST node. Later, during the execution of a `CachedDispatchNode`, the new type-checking dispatch guards use these `SomStructuralType` objects to verify whether a given argument conforms to the expected type. If the argument does not conform, a SOM `ArgumentError` is thrown (this may be caught later in the Grace program, but if not caught the error will be reported and SOMns will exit).

More information about each part of this implementation is described below.

### New type-checking dispatch guards

To provide an efficient implementation, I've added five different guards: a no-op guard, literal guards, and a structural guard. The no-op guard always returns true and is used when the type of an parameter is omitted. The literal guards - one for boolean, number, and string - are used when the argument is literal; their verification is performed in terms of a simple `instance of` check. And finally, the structural guard performs the Boyland-style check: verifying that the given object can respond to each of the signatures defined by the type.

### SOM Structural Type

As briefly described above, Grace's type statements are translated into instances of the new `SomStructuralType` class. This class implements the logic of enumerating its list of signatures to verify whether a given object conforms to it. The enumeration step requires access to the definition of the `MixinDefintion` of the argument - which we access through a reflection primitive.   Since the check is expensive this class only does the enumeration once for each unique `MixinDefintion`, caching the result immediately after the check (results are indexed by the `MixinDefinition` and so the check reduces to a reference equality comparison). 

### Parsing, translation, and SOM AST

Only minor changes to the parser have been added: I've extended the`JsonTreeTranslator` to translate type statements into instances of `SomStructuralType` and to extract type annotations on method parameters, which are then used by the `AstBuilder`. When the SOM AST for each method is assembled, information about its expected types gets included with the generated SOM AST (see `SInvokable`). 

### Problems to address

There may be an issue with the caching used in the `SomStructuralType`. In particular, `MixinDefintion`s can be split during run time. After being split, the `SomStructuralType` may report a failure (since the cloned `MixinDefinition` is no longer equal to one that was used to index the result) even though the new copy of the mixin responds to the same signatures?

For the sake of being able to easily add type annotations to the existing [benchmarks](https://github.com/richard-roberts/GraceLibrary/tree/master/Benchmarks) (these require the use of some kind of `nil` object, I've decided to enable Grace's `Done` to pass all type checks. As far as I understand, this is against Grace's semantics and so I will most likely revisit this later.