### PR TITLE
Changing the Oil

### DIFF
--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -263,6 +263,7 @@ class Kernel vmMirror: vmMirror = Object <: Value (
     public + argument  = ( ^ vmMirror double: self add: argument )
     public - argument  = ( ^ vmMirror double: self subtract: argument )
     public * argument  = ( ^ vmMirror double: self multiply: argument )
+    public / argument = ( ^ self // argument )
     public // argument = ( ^ vmMirror double: self divideDouble: argument )
     public % argument  = ( ^ vmMirror double: self modulo: argument )
     public abs         = ( ^ (self < 0.0) ifTrue: (0.0 - self) ifFalse: self )

--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -310,6 +310,7 @@ class Kernel vmMirror: vmMirror = Object <: Value (
     (* Concatenate: returns a new string object *)
     public concatenate: argument = ( ^ vmMirror string: self concat: argument )
     public + argument            = ( ^ self concatenate: argument asString )
+    public ++ argument            = ( ^ self + argument )
 
     (* Converting *)
     public asString = ( ^ self )

--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -76,13 +76,16 @@ class Kernel vmMirror: vmMirror = Object <: Value (
   public class Object = Thing ()
   (
     public == other = ( ^ vmMirror object: self identicalTo: other )
+    public = other  = ( ^ self == other )
     public ~= other = ( ^ (self == other) not )
   )
 
   public class Value = Thing ()
   (
     public =  other = ( ^ vmMirror value: self sameAs: other )
+    public ==  other = ( ^ self = other )
     public <> other = ( ^ (self = other) not )
+    public != other = ( ^ self <> other )
     public copy = ( ^ self )
   )
 

--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -186,7 +186,9 @@ class Kernel vmMirror: vmMirror = Object <: Value (
     (* Bit operations *)
     public & argument  = ( ^ vmMirror int: self bitAnd: argument )
     public << argument = ( ^ vmMirror int: self leftShift: argument )
+    public bitLeftShift: argument = ( ^ self << argument )
     public >>> argument= ( ^ vmMirror int: self unsignedRightShift: argument )
+    public bitRightShift: argument = ( ^ self >>> argument )
     public bitOr: argument  = ( ^ vmMirror int: self bitOr: argument )
     public bitXor: argument = ( ^ vmMirror int: self bitXor: argument )
 

--- a/src/som/Output.java
+++ b/src/som/Output.java
@@ -34,19 +34,23 @@ public class Output {
 
   @TruffleBoundary
   private static void print(final String msg, final String color, final PrintStream s) {
+    String ret = msg.replace("\\n", System.getProperty("line.separator"));
+
     if (VmSettings.ANSI_COLOR_IN_OUTPUT) {
-      s.print(color + msg + AnsiColor8.RESET);
+      s.print(color + ret + AnsiColor8.RESET);
     } else {
-      s.print(msg);
+      s.print(ret);
     }
   }
 
   @TruffleBoundary
   private static void println(final String msg, final String color, final PrintStream s) {
+    String ret = msg.replace("\\n", System.getProperty("line.separator"));
+
     if (VmSettings.ANSI_COLOR_IN_OUTPUT) {
-      s.println(color + msg + AnsiColor8.RESET);
+      s.println(color + ret + AnsiColor8.RESET);
     } else {
-      s.println(msg);
+      s.println(ret);
     }
   }
 

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -738,7 +738,7 @@ public class AstBuilder {
       // Translate first receiver as `expression.toString`
       JsonObject firstObj = elements.get(0).getAsJsonObject();
       ExpressionNode receiver = (ExpressionNode) translator.translate(firstObj);
-      receiver = explicit(symbolFor("toString"), receiver, new ArrayList<ExpressionNode>(),
+      receiver = explicit(symbolFor("asString"), receiver, new ArrayList<ExpressionNode>(),
           translator.source(firstObj));
 
       for (int i = 0; i < elements.size(); i++) {
@@ -746,7 +746,7 @@ public class AstBuilder {
 
         // Set operand as `expression.toString`
         ExpressionNode operand = (ExpressionNode) translator.translate(operandObj);
-        operand = explicit(symbolFor("toString"), operand, new ArrayList<ExpressionNode>(),
+        operand = explicit(symbolFor("asString"), operand, new ArrayList<ExpressionNode>(),
             translator.source(operandObj));
 
         // Add operand to receiver

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -741,7 +741,7 @@ public class AstBuilder {
       receiver = explicit(symbolFor("asString"), receiver, new ArrayList<ExpressionNode>(),
           translator.source(firstObj));
 
-      for (int i = 0; i < elements.size(); i++) {
+      for (int i = 1; i < elements.size(); i++) {
         JsonObject operandObj = elements.get(i).getAsJsonObject();
 
         // Set operand as `expression.toString`

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -791,5 +791,13 @@ public class AstBuilder {
     public ExpressionNode string(final String value, final SourceSection sourceSection) {
       return new StringLiteralNode(value).initialize(sourceSection);
     }
+
+    public Object array(final JsonObject[] arguments, final SourceSection sourceSection) {
+      ExpressionNode[] exprs = new ExpressionNode[arguments.length];
+      for (int i = 0; i < arguments.length; i++) {
+        exprs[i] = (ExpressionNode) translator.translate(arguments[i]);
+      }
+      return ArrayLiteralNode.create(exprs, sourceSection);
+    }
   }
 }

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -378,7 +378,7 @@ public class AstBuilder {
 
       // Munge the name of the class
       SSymbol clazzName = symbolFor(objectName.getString() + "[Class]");
-      MixinBuilder builder = scopeManager.newClazz(clazzName, sourceManager.empty());
+      MixinBuilder builder = scopeManager.newObject(clazzName, sourceManager.empty());
 
       // Create the initialization method
       MethodBuilder instanceFactory = builder.getPrimaryFactoryMethodBuilder();
@@ -419,7 +419,7 @@ public class AstBuilder {
       scopeManager.popMethod();
 
       // Assemble and return the completed module
-      MixinDefinition classDef = scopeManager.assumbleCurrentClazz(sourceManager.empty());
+      MixinDefinition classDef = scopeManager.assumbleCurrentObject(sourceManager.empty());
       ExpressionNode outerRead = scopeManager.peekMethod().getSelfRead(sourceSection);
       ExpressionNode newMessage = createMessageSend(Symbols.NEW,
           new ExpressionNode[] {scopeManager.peekMethod().getSelfRead(sourceSection)},

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -482,8 +482,10 @@ public class AstBuilder {
      *
      * #foo__λ5@8::
      */
-    public ExpressionNode block(final SSymbol[] parameters, final SSymbol[] locals,
-        final JsonArray body, final SourceSection sourceSection) {
+    public ExpressionNode block(final SSymbol[] parameters,
+        final SourceSection[] parameterSources, final SSymbol[] locals,
+        final SourceSection[] sourceLocals, final JsonArray body,
+        final SourceSection sourceSection) {
 
       // Generate the signature for the block
       int line = sourceSection.getStartLine();
@@ -501,13 +503,13 @@ public class AstBuilder {
       // Set the parameters
       builder.addUntypedArgument(Symbols.BLOCK_SELF, sourceManager.empty());
       for (int i = 0; i < parameters.length; i++) {
-        builder.addUntypedArgument(parameters[i], sourceManager.empty());
+        builder.addUntypedArgument(parameters[i], parameterSources[i]);
       }
 
       // Set the locals
       for (int i = 0; i < locals.length; i++) {
         try {
-          builder.addLocal(locals[i], false, sourceManager.empty());
+          builder.addLocal(locals[i], false, sourceLocals[i]);
         } catch (MethodDefinitionError e) {
           language.getVM().errorExit("Failed to add " + locals[i] + " to "
               + builder.getSignature() + ": " + e.getMessage());

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -658,8 +658,14 @@ public class JsonTreeTranslator {
       return translate(node.get("expression").getAsJsonObject());
 
     } else if (nodeType(node).equals("return")) {
-      ExpressionNode returnExpression =
-          (ExpressionNode) translate(node.get("returnvalue").getAsJsonObject());
+      ExpressionNode returnExpression;
+      if (node.get("returnvalue").isJsonNull()) {
+        returnExpression = astBuilder.literalBuilder.done(source(node));
+      } else {
+        returnExpression =
+            (ExpressionNode) translate(node.get("returnvalue").getAsJsonObject());
+      }
+
       if (scopeManager.peekMethod().isBlockMethod()) {
         return astBuilder.requestBuilder.makeBlockReturn(returnExpression, source(node));
       } else {

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -90,6 +90,16 @@ public class JsonTreeTranslator {
     return sourceManager.atLineColumn(line, column);
   }
 
+  private void error(final String message, final JsonObject node) {
+    String prefix = "";
+    if (node != null) {
+      int line = node.get("line").getAsInt();
+      int column = node.get("column").getAsInt();
+      prefix = "[" + line + "," + column + "] ";
+    }
+    language.getVM().errorExit(prefix + message);
+  }
+
   /**
    * Gets the type of a {@link JsonObject}, which should be a string stored in the "nodetype"
    * field.
@@ -128,8 +138,8 @@ public class JsonTreeTranslator {
       return name(node.get("from").getAsJsonObject());
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get a name from " + nodeType(node));
+      error("The translator doesn't understand how to get a name from " + nodeType(node),
+          node);
       throw new RuntimeException();
     }
   }
@@ -158,8 +168,8 @@ public class JsonTreeTranslator {
     if (node.get("path").isJsonObject()) {
       return node.get("path").getAsJsonObject().get("raw").getAsString();
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get a path from " + nodeType(node));
+      error("The translator doesn't understand how to get a path from " + nodeType(node),
+          node);
       throw new RuntimeException();
     }
   }
@@ -189,8 +199,8 @@ public class JsonTreeTranslator {
       return translate(node.get("right").getAsJsonObject());
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get a value from " + nodeType(node));
+      error("The translator doesn't understand how to get a value from " + nodeType(node),
+          node);
       throw new RuntimeException();
     }
   }
@@ -204,9 +214,9 @@ public class JsonTreeTranslator {
     } else if (part.has("parameters")) {
       return part.get("parameters").getAsJsonArray().size();
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to count the arguments or parameters for the part: "
-              + part);
+      error(
+          "The translator doesn't understand how to count the arguments or parameters for the part",
+          part);
       throw new RuntimeException();
     }
 
@@ -242,8 +252,8 @@ public class JsonTreeTranslator {
       return node.get("left").getAsJsonObject();
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get a receiver from " + nodeType(node));
+      error("The translator doesn't understand how to get a receiver from " + nodeType(node),
+          node);
       throw new RuntimeException();
     }
   }
@@ -262,8 +272,8 @@ public class JsonTreeTranslator {
       return symbolFor("negated");
 
     } else {
-      language.getVM().errorExit("The translator doesn't understand what to do with the `"
-          + name + "` prefix operator");
+      error("The translator doesn't understand what to do with the `" + name
+          + "` prefix operator", null);
       throw new RuntimeException();
     }
   }
@@ -298,8 +308,8 @@ public class JsonTreeTranslator {
       return symbolFor(operator);
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get a name from " + nodeType(node));
+      error("The translator doesn't understand how to a selector from " + nodeType(node),
+          node);
       throw new RuntimeException();
     }
   }
@@ -340,8 +350,10 @@ public class JsonTreeTranslator {
       }
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get arguments from " + node);
+      error(
+          "The translator doesn't understand how to get arguments from a " + nodeType(node)
+              + "node",
+          node);
       throw new RuntimeException();
     }
   }
@@ -382,8 +394,7 @@ public class JsonTreeTranslator {
       return parametersNames.toArray(new SSymbol[parametersNames.size()]);
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get parameters from " + node);
+      error("The translator doesn't understand how to get parameters from " + node, node);
       throw new RuntimeException();
     }
   }
@@ -430,8 +441,7 @@ public class JsonTreeTranslator {
       return "Unknown";
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get type for " + nodeType);
+      error("The translator doesn't understand how to get type for " + nodeType, node);
       throw new RuntimeException();
     }
   }
@@ -455,8 +465,8 @@ public class JsonTreeTranslator {
       return types.toArray(new SSymbol[types.size()]);
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand how to get parameters from " + node);
+      error("The translator doesn't understand how to get parameters from " + nodeType(node),
+          node);
       throw new RuntimeException();
     }
   }
@@ -664,8 +674,8 @@ public class JsonTreeTranslator {
       return astBuilder.requestBuilder.interpolatedString(node.get("parts").getAsJsonArray());
 
     } else {
-      language.getVM().errorExit(
-          "The translator doesn't understand what to do with a " + nodeType(node) + " node?");
+      error("The translator doesn't understand what to do with a " + nodeType(node) + " node?",
+          node);
       throw new RuntimeException();
     }
   }

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -341,6 +341,14 @@ public class JsonTreeTranslator {
     if (node.has("parts")) {
       return argumentsFromParts(node.get("parts").getAsJsonArray());
 
+    } else if (node.has("arguments")) {
+      JsonArray args = node.get("arguments").getAsJsonArray();
+      JsonObject[] ret = new JsonObject[args.size()];
+      for (int i = 0; i < args.size(); i++) {
+        ret[i] = args.get(i).getAsJsonObject();
+      }
+      return ret;
+
     } else if (node.has("right")) {
       return new JsonObject[] {node.get("right").getAsJsonObject()};
 
@@ -692,6 +700,9 @@ public class JsonTreeTranslator {
 
     } else if (nodeType(node).equals("interpolated-string")) {
       return astBuilder.requestBuilder.interpolatedString(node.get("parts").getAsJsonArray());
+
+    } else if (nodeType(node).equals("implicit-bracket-request")) {
+      return astBuilder.literalBuilder.array(arguments(node), source(node));
 
     } else {
       error("The translator doesn't understand what to do with a " + nodeType(node) + " node?",

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -258,6 +258,9 @@ public class JsonTreeTranslator {
     if (name.equals("prefix!") || name.equals("!")) {
       return symbolFor("not");
 
+    } else if (name.equals("prefix-") || name.equals("-")) {
+      return symbolFor("negated");
+
     } else {
       language.getVM().errorExit("The translator doesn't understand what to do with the `"
           + name + "` prefix operator");

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -184,7 +184,7 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
     Local loopIdx;
     if (blockOrVal instanceof BlockNode) {
       Argument[] args = ((BlockNode) blockOrVal).getArguments();
-      assert args.length == 2;
+      assert args.length == 2 : "Did you put enough parameters on the block?";
       loopIdx = getLocal(args[1].getQualifiedName());
     } else {
       // if it is a literal, we still need a memory location for counting, so,

--- a/src/som/compiler/ScopeManager.java
+++ b/src/som/compiler/ScopeManager.java
@@ -131,6 +131,19 @@ public class ScopeManager {
   }
 
   /**
+   * Creates a builder that makes an object literal inside the current method
+   */
+  public MixinBuilder newObject(final SSymbol clazzName, final SourceSection empty) {
+    MixinBuilder builder =
+        new MixinBuilder(peekMethod(),
+            AccessModifier.PUBLIC, // not sure if this is required to be PUBLIC
+            clazzName,
+            empty, probe, language);
+    pushObject(builder);
+    return builder;
+  }
+
+  /**
    * Creates a builder that makes a method for the object sitting at the top of the object
    * stack
    *
@@ -221,6 +234,18 @@ public class ScopeManager {
       throw new RuntimeException();
     }
 
+    return result;
+  }
+
+  /**
+   * Produces a finished class definition by assembling the object at the top of the stack
+   * (this class is anonymous and therefore not added anything enclosing it.
+   *
+   * @throws MixinDefinitionError
+   * @return - the assembled class definition
+   */
+  public MixinDefinition assumbleCurrentObject(final SourceSection sourceSection) {
+    MixinDefinition result = popObject().assemble(sourceSection);
     return result;
   }
 

--- a/src/som/compiler/SourceManager.java
+++ b/src/som/compiler/SourceManager.java
@@ -88,6 +88,7 @@ public class SourceManager {
     builtinModules.add("standardGrace");
     builtinModules.add("io");
     builtinModules.add("mirrors");
+    builtinModules.add("random");
   }
 
   public String pathForModuleNamed(final SSymbol moduleName) {


### PR DESCRIPTION
These changes fix bugs, adding more missing operators and mappings, and generally improve my quality of life working with Moth.

The most significant changes are that `return` expressions that omit a value now returns SOM's `nil` value (as a stand-in for Grace's `Done`); the `[ ... ]` syntax can now be used to produce SOM's Array literal's (as a stand-in for Grace's default collection); and the assignments can be made via explicit requests (as in `x.y := e`).  

The minor changes are listed under the headings below.

## Bug Fixes

- String interpolation has been fixed (the receiver is no longer duplicated and the correct method is now invoked).
- Whitespace is now formatted correctly when printed to standard out.
- Blocks variables have been assigned source information (required to avoid variable name clashes after inlining).

## Operators

Until we create an object system for Grace, we rely on the SOM object system to provide support for Grace's built-in objects. Changes to the SOM object system here are as follows: 

- The `prefix-` operator is now mapping to SOM's `negated`
- Missing equality operators have been added
- Both SOM `Integer` and `Double` now understand `/`
- `++` has been added to SOM `String` 

## Quality of Life

Finally, I've added a note to explain an assertion that is thrown when a block used for iteration is missing its iterator parameter and also added line and column numbers to errors thrown by `JsonTreeTranslator`.