### PR TITLE
Revisiting support for shallow checking

### DIFF
--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -978,6 +978,15 @@ class Kernel vmMirror: vmMirror = Object <: Value (
     )
   )
 
+  public class TypeError signalWith: argument = Exception (
+    | public arg = argument. |
+    self signal.
+  )(
+    public asString = (
+      ^ 'TypeError: ' + arg + ''.
+    )
+  )
+
   (* Exception signaled when a Value is instantiated referring to a mutable object. *)
   public class NotAValue signalWith: aClass = Exception (
     | public class = aClass. |
@@ -1015,4 +1024,10 @@ class Kernel vmMirror: vmMirror = Object <: Value (
   private signalArgumentError: message = (
     ArgumentError signalWith: message.
   )
+
+  (* Short cut from VM. Likely to be removed when optimized. *)
+  private signalTypeError: message = (
+    TypeError signalWith: message.
+  )
+
 )

--- a/som
+++ b/som
@@ -124,6 +124,9 @@ parser.add_argument('-D', help="define a Java property",
 parser.add_argument('-ac', '--ansi-coloring', help='Enable ANSI coloring for output from interpreter with true, or disable with false',
                     dest='use_ansi_coloring', action='store', default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty())
 
+parser.add_argument('-tc', '--type-checking', help='Enable type checking with true, or disable with false',
+                    dest='use_type_checking', action='store_true', default=False)
+
 parser.add_argument('args', nargs=argparse.REMAINDER,
                     help='arguments passed to SOMns')
 
@@ -238,6 +241,9 @@ if args.som_dnu:
 
 if args.use_ansi_coloring:
     flags += ['-Dsom.useAnsiColoring=' + str(args.use_ansi_coloring).lower()]
+
+if args.use_type_checking:
+    flags += ['-Dsom.useTypeChecking=true']
 
 # Handle executable names
 if sys.argv[0].endswith('fast'):

--- a/som
+++ b/som
@@ -127,6 +127,9 @@ parser.add_argument('-ac', '--ansi-coloring', help='Enable ANSI coloring for out
 parser.add_argument('-tc', '--type-checking', help='Enable type checking with true, or disable with false',
                     dest='use_type_checking', action='store_true', default=False)
 
+parser.add_argument('-eft', '--ensure-fully-typed', help='Enable errors when any possible type annotation is missing with true, or disable with false',
+                    dest='ensure_fully_typed', action='store_true', default=False)
+
 parser.add_argument('args', nargs=argparse.REMAINDER,
                     help='arguments passed to SOMns')
 
@@ -244,6 +247,9 @@ if args.use_ansi_coloring:
 
 if args.use_type_checking:
     flags += ['-Dsom.useTypeChecking=true']
+
+if args.ensure_fully_typed:
+    flags += ['-Dsom.ensureFullyTyped=true']
 
 # Handle executable names
 if sys.argv[0].endswith('fast'):

--- a/src/som/compiler/AstBuilder.java
+++ b/src/som/compiler/AstBuilder.java
@@ -58,7 +58,6 @@ import som.interpreter.nodes.literals.LiteralNode;
 import som.interpreter.nodes.literals.NilLiteralNode;
 import som.interpreter.nodes.literals.ObjectLiteralNode;
 import som.interpreter.nodes.literals.StringLiteralNode;
-import som.vm.SomStructuralType;
 import som.vm.Symbols;
 import som.vmobjects.SSymbol;
 import tools.language.StructuralProbe;
@@ -103,7 +102,7 @@ public class AstBuilder {
      * Adds an immutable slot to the object currently at the top of stack. The slot will be
      * initialized by executing the given expressions.
      */
-    public void addImmutableSlot(final SSymbol slotName, final SomStructuralType type,
+    public void addImmutableSlot(final SSymbol slotName, final SSymbol type,
         final ExpressionNode init,
         final SourceSection sourceSection) {
       try {
@@ -120,7 +119,7 @@ public class AstBuilder {
      * Adds a mutable slot to the object currently at the top of stack. The slot will be
      * initialized to nil.
      */
-    public void addMutableSlot(final SSymbol slotName, final SomStructuralType type,
+    public void addMutableSlot(final SSymbol slotName, final SSymbol type,
         final SourceSection sourceSection) {
       try {
         scopeManager.peekObject().addSlot(slotName, type, AccessModifier.PUBLIC, false, null,
@@ -149,7 +148,7 @@ public class AstBuilder {
      *
      * @return - the assembled class corresponding to the module
      */
-    public MixinDefinition module(final SSymbol[] locals, final SomStructuralType[] localTypes,
+    public MixinDefinition module(final SSymbol[] locals, final SSymbol[] localTypes,
         final SourceSection[] localSources, final JsonArray body,
         final SourceSection sourceSection) {
       SSymbol moduleName = symbolFor(sourceManager.getModuleName());
@@ -251,10 +250,10 @@ public class AstBuilder {
      * this solution is simple. I will revisit this solution and attempt to develop a better
      * solution later.
      */
-    public void clazzDefinition(final SSymbol name, final SomStructuralType returnType,
-        final SSymbol[] parameters, final SomStructuralType[] parameterTypes,
+    public void clazzDefinition(final SSymbol name, final SSymbol returnType,
+        final SSymbol[] parameters, final SSymbol[] parameterTypes,
         final SourceSection[] parameterSources, final SSymbol[] locals,
-        final SomStructuralType[] localTypes, final SourceSection[] localSources,
+        final SSymbol[] localTypes, final SourceSection[] localSources,
         final JsonArray body, final SourceSection sourceSection) {
 
       // Munge the name of the class
@@ -334,9 +333,9 @@ public class AstBuilder {
     /**
      * Creates a method that returns an instance of the named class.
      */
-    public void clazzMethod(final SSymbol name, final SomStructuralType returnType,
+    public void clazzMethod(final SSymbol name, final SSymbol returnType,
         final SSymbol[] parameters,
-        final SomStructuralType[] parameterTypes, final SourceSection[] parameterSources,
+        final SSymbol[] parameterTypes, final SourceSection[] parameterSources,
         final SourceSection sourceSection) {
       MethodBuilder builder = scopeManager.newMethod(name, null);
       builder.setReturnType(returnType);
@@ -387,7 +386,7 @@ public class AstBuilder {
      * <munged method name>θ<line>@<column>
      */
     public ExpressionNode objectConstructor(final SSymbol[] locals,
-        final SomStructuralType[] localTypes, final SourceSection[] localSources,
+        final SSymbol[] localTypes, final SourceSection[] localSources,
         final JsonArray body, final SourceSection sourceSection) {
 
       // Generate the signature for the block
@@ -550,8 +549,8 @@ public class AstBuilder {
      * #foo__λ5@8::
      */
     public ExpressionNode block(final SSymbol[] parameters,
-        final SomStructuralType[] parameterTypes, final SourceSection[] parameterSources,
-        final SSymbol[] locals, final SomStructuralType[] localTypes,
+        final SSymbol[] parameterTypes, final SourceSection[] parameterSources,
+        final SSymbol[] locals, final SSymbol[] localTypes,
         final SourceSection[] localSources, final JsonArray body,
         final SourceSection sourceSection) {
 
@@ -612,10 +611,10 @@ public class AstBuilder {
      * Adds a method with the given selector, variables, and body to the object at the top of
      * the stack.
      */
-    public void method(final SSymbol selector, final SomStructuralType returnType,
-        final SSymbol[] parameters, final SomStructuralType[] parameterTypes,
+    public void method(final SSymbol selector, final SSymbol returnType,
+        final SSymbol[] parameters, final SSymbol[] parameterTypes,
         final SourceSection[] parameterSources, final SSymbol[] locals,
-        final SomStructuralType[] localTypes, final SourceSection[] localSources,
+        final SSymbol[] localTypes, final SourceSection[] localSources,
         final JsonArray body, final SourceSection sourceSection) {
       MethodBuilder builder = scopeManager.newMethod(selector, returnType);
 

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -43,6 +43,7 @@ import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
 import som.vm.SomStructuralType;
+import som.vm.VmSettings;
 import som.vmobjects.SSymbol;
 import tools.language.StructuralProbe;
 
@@ -264,7 +265,11 @@ public class JsonTreeTranslator {
     }
   }
 
-  private SomStructuralType returnType(final JsonObject node) {
+  private SSymbol returnType(final JsonObject node) {
+    if (!VmSettings.USE_TYPE_CHECKING) { // simply return null if type checking not used
+      return null;
+    }
+
     JsonObject signatureNode = node.get("signature").getAsJsonObject();
     if (signatureNode.get("returntype").isJsonNull()) {
       return null;
@@ -425,6 +430,10 @@ public class JsonTreeTranslator {
    * typed-parameter or otherwise a simple identifier.
    */
   private SomStructuralType typeFor(final JsonObject node) {
+    if (!VmSettings.USE_TYPE_CHECKING) { // simply return null if type checking not used
+      return null;
+    }
+
     String nodeType = nodeType(node);
 
     if (nodeType.equals("typed-parameter")) {
@@ -717,8 +726,10 @@ public class JsonTreeTranslator {
           sourcesForLocals(node), body(node), source(node));
 
     } else if (nodeType(node).equals("type-statement")) {
-      SomStructuralType.recordTypeByName(symbolFor(name(node)),
-          SomStructuralType.makeType(parseTypeSignatures(node)));
+      if (VmSettings.USE_TYPE_CHECKING) {
+        SomStructuralType.recordTypeByName(symbolFor(name(node)),
+            SomStructuralType.makeType(parseTypeSignatures(node)));
+      }
       return null;
 
     } else if (nodeType(node).equals("block")) {

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -273,11 +273,9 @@ public class JsonTreeTranslator {
 
     JsonObject signatureNode = node.get("signature").getAsJsonObject();
     if (signatureNode.get("returntype").isJsonNull()) {
-      if (!sourceManager.isBuiltInModule()) {
-        if (VmSettings.MUST_BE_FULLY_TYPED) {
-          error(nodeType(node) + " is missing a type annotation", node);
-          throw new RuntimeException();
-        }
+      if (VmSettings.MUST_BE_FULLY_TYPED) {
+        error(nodeType(node) + " is missing a type annotation", node);
+        throw new RuntimeException();
       }
 
       return SomStructuralType.UNKNOWN;
@@ -462,11 +460,9 @@ public class JsonTreeTranslator {
       throw new RuntimeException();
     }
 
-    if (!sourceManager.isBuiltInModule()) {
-      if (VmSettings.MUST_BE_FULLY_TYPED) {
-        error(nodeType + " is missing a type annotation", node);
-        throw new RuntimeException();
-      }
+    if (VmSettings.MUST_BE_FULLY_TYPED) {
+      error(nodeType + " is missing a type annotation", node);
+      throw new RuntimeException();
     }
     return SomStructuralType.UNKNOWN;
   }

--- a/src/som/compiler/JsonTreeTranslator.java
+++ b/src/som/compiler/JsonTreeTranslator.java
@@ -30,6 +30,7 @@ package som.compiler;
 
 import static som.vm.Symbols.symbolFor;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -828,8 +829,15 @@ public class JsonTreeTranslator {
       return null;
 
     } else if (nodeType(node).equals("import")) {
+      String path = path(node);
+      try {
+        language.getVM().loadModule(sourceManager.pathForModuleNamed(symbolFor(path)));
+      } catch (IOException e) {
+        error("An error was throwing when eagerly parsing " + path, node);
+        throw new RuntimeException();
+      }
       ExpressionNode importExpression =
-          astBuilder.requestBuilder.importModule(symbolFor(path(node)), source(node));
+          astBuilder.requestBuilder.importModule(symbolFor(path), source(node));
       astBuilder.objectBuilder.addImmutableSlot(symbolFor(name(node)), null, importExpression,
           source(node));
       return null;

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -71,8 +71,8 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
 
   private final SomLanguage language;
 
-  private SSymbol           signature;
-  private SomStructuralType returnType;
+  private SSymbol signature;
+  private SSymbol returnType;
 
   private final List<SourceSection> definition = new ArrayList<>(3);
 
@@ -303,13 +303,13 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
 
       // skip self
       if (i != 0) {
-        types.add(arg.type);
+        types.add(SomStructuralType.recallTypeByName(arg.type));
       }
 
       i += 1;
     }
 
-    types.add(returnType);
+    types.add(SomStructuralType.recallTypeByName(returnType));
 
     return types.toArray(new SomStructuralType[types.size()]);
   }
@@ -378,11 +378,11 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
     signature = sig;
   }
 
-  public void setReturnType(final SomStructuralType returnType) {
+  public void setReturnType(final SSymbol returnType) {
     this.returnType = returnType;
   }
 
-  public void addArgument(final SSymbol arg, final SomStructuralType type,
+  public void addArgument(final SSymbol arg, final SSymbol type,
       final SourceSection source) {
     if ((Symbols.SELF == arg || Symbols.BLOCK_SELF == arg) && arguments.size() > 0) {
       throw new IllegalStateException(
@@ -406,7 +406,7 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
     return l;
   }
 
-  public Local addLocal(final SSymbol name, final SomStructuralType type,
+  public Local addLocal(final SSymbol name, final SSymbol type,
       final boolean immutable, final SourceSection source) throws MethodDefinitionError {
     if (arguments.containsKey(name)) {
       throw new MethodDefinitionError("Method already defines argument " + name
@@ -428,7 +428,7 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
     return l;
   }
 
-  private Local addLocalAndUpdateScope(final SSymbol name, final SomStructuralType type,
+  private Local addLocalAndUpdateScope(final SSymbol name, final SSymbol type,
       final boolean immutable, final SourceSection source) throws MethodDefinitionError {
     Local l = addLocal(name, type, immutable, source);
     scope.addVariable(l);

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -701,8 +701,7 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
     }
 
     embeddedMixins.put(name, nestedMixin);
-    ClassSlotDefinition cacheSlot =
-        new ClassSlotDefinition(name, nestedMixin.getType(), nestedMixin);
+    ClassSlotDefinition cacheSlot = new ClassSlotDefinition(name, null, nestedMixin);
     dispatchables.put(name, cacheSlot);
     slots.put(name, cacheSlot);
   }

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -49,7 +49,6 @@ import som.interpreter.nodes.IsValueCheckNode;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.interpreter.objectstorage.InitializerFieldWrite;
 import som.primitives.NewObjectPrimNodeGen;
-import som.vm.SomStructuralType;
 import som.vm.Symbols;
 import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
@@ -354,7 +353,7 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
     }
   }
 
-  public void addSlot(final SSymbol name, final SomStructuralType type,
+  public void addSlot(final SSymbol name, final SSymbol type,
       final AccessModifier acccessModifier, final boolean immutable, final ExpressionNode init,
       final SourceSection source) throws MixinDefinitionError {
     if (dispatchables.containsKey(name)) {
@@ -507,7 +506,7 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
    * signature.
    */
   public void addArgumentToSuperClassResolutionBuilder(final SSymbol name,
-      final SomStructuralType type, final SourceSection sourceSection) {
+      final SSymbol type, final SourceSection sourceSection) {
     superclassAndMixinResolutionBuilder.addArgument(name, type, sourceSection);
     String newSelector = superclassAndMixinResolutionBuilder.getSignature().getString() + ":";
     superclassAndMixinResolutionBuilder.setSignature(symbolFor(newSelector));

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -818,8 +818,4 @@ public final class MixinDefinition {
     clone.adaptInvokableDispatchables(adaptedScope, appliesTo);
     return clone;
   }
-
-  public SomStructuralType getType() {
-    return SomStructuralType.getTypeFromMixin(this);
-  }
 }

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -498,15 +498,15 @@ public final class MixinDefinition {
   // should split out the definition, and the accessor related stuff
   // perhaps move some of the responsibilities to SlotAccessNode???
   public static class SlotDefinition implements Dispatchable {
-    private final SSymbol             name;
-    protected final SomStructuralType type;
-    protected final AccessModifier    modifier;
-    private final boolean             immutable;
-    protected final SourceSection     source;
+    private final SSymbol          name;
+    protected final SSymbol        type;
+    protected final AccessModifier modifier;
+    private final boolean          immutable;
+    protected final SourceSection  source;
 
     @CompilationFinal protected CallTarget genericAccessTarget;
 
-    public SlotDefinition(final SSymbol name, final SomStructuralType type,
+    public SlotDefinition(final SSymbol name, final SSymbol type,
         final AccessModifier acccessModifier, final boolean immutable,
         final SourceSection source) {
       this.name = name;
@@ -552,7 +552,8 @@ public final class MixinDefinition {
       CachedSlotRead read =
           createNode(loc, DispatchGuard.createSObjectCheck(rcvr),
               type == null ? null
-                  : TypeCheckNodeGen.create(type, loc.getSlot().getSourceSection()),
+                  : TypeCheckNodeGen.create(SomStructuralType.recallTypeByName(type),
+                      loc.getSlot().getSourceSection()),
               next,
               isSet);
 
@@ -560,7 +561,9 @@ public final class MixinDefinition {
           getAccessType() == SlotAccess.FIELD_READ) {
         return new CachedTxSlotRead(getAccessType(), read,
             DispatchGuard.createSObjectCheck(rcvr),
-            TypeCheckNodeGen.create(type, getSourceSection()), next);
+            TypeCheckNodeGen.create(SomStructuralType.recallTypeByName(type),
+                getSourceSection()),
+            next);
       } else {
         return read;
       }
@@ -609,7 +612,7 @@ public final class MixinDefinition {
 
     private SlotDefinition mainSlot;
 
-    public SlotMutator(final SSymbol name, final SomStructuralType type,
+    public SlotMutator(final SSymbol name, final SSymbol type,
         final AccessModifier acccessModifier, final boolean immutable,
         final SourceSection source, final SlotDefinition mainSlot) {
       super(name, type, acccessModifier, immutable, source);
@@ -626,14 +629,17 @@ public final class MixinDefinition {
       CachedSlotWrite write =
           loc.getWriteNode(mainSlot, DispatchGuard.createSObjectCheck(rcvr),
               type == null ? null
-                  : TypeCheckNodeGen.create(type, loc.getSlot().getSourceSection()),
+                  : TypeCheckNodeGen.create(SomStructuralType.recallTypeByName(type),
+                      loc.getSlot().getSourceSection()),
               next,
               isSet);
 
       if (forAtomic) {
         return new CachedTxSlotWrite(write,
             DispatchGuard.createSObjectCheck(rcvr),
-            TypeCheckNodeGen.create(type, loc.getSlot().getSourceSection()), next);
+            TypeCheckNodeGen.create(SomStructuralType.recallTypeByName(type),
+                loc.getSlot().getSourceSection()),
+            next);
       } else {
         return write;
       }
@@ -656,7 +662,7 @@ public final class MixinDefinition {
   public static final class ClassSlotDefinition extends SlotDefinition {
     private final MixinDefinition mixinDefinition;
 
-    public ClassSlotDefinition(final SSymbol name, final SomStructuralType type,
+    public ClassSlotDefinition(final SSymbol name, final SSymbol type,
         final MixinDefinition mixinDefinition) {
       super(name, type, mixinDefinition.getAccessModifier(), true,
           mixinDefinition.getSourceSection());

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -551,7 +551,7 @@ public final class MixinDefinition {
 
       CachedSlotRead read =
           createNode(loc, DispatchGuard.createSObjectCheck(rcvr),
-              type == null ? null
+              SomStructuralType.isNullOrUnknown(type) ? null
                   : TypeCheckNodeGen.create(SomStructuralType.recallTypeByName(type),
                       loc.getSlot().getSourceSection()),
               next,
@@ -628,7 +628,7 @@ public final class MixinDefinition {
       boolean isSet = loc.isSet(rcvr);
       CachedSlotWrite write =
           loc.getWriteNode(mainSlot, DispatchGuard.createSObjectCheck(rcvr),
-              type == null ? null
+              SomStructuralType.isNullOrUnknown(type) ? null
                   : TypeCheckNodeGen.create(SomStructuralType.recallTypeByName(type),
                       loc.getSlot().getSourceSection()),
               next,

--- a/src/som/compiler/ScopeManager.java
+++ b/src/som/compiler/ScopeManager.java
@@ -37,7 +37,6 @@ import som.compiler.MixinBuilder.MixinDefinitionError;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.SequenceNode;
-import som.vm.SomStructuralType;
 import som.vm.VmSettings;
 import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
@@ -153,7 +152,7 @@ public class ScopeManager {
    *          code)
    * @return the builder
    */
-  public MethodBuilder newMethod(final SSymbol signature, final SomStructuralType returnType) {
+  public MethodBuilder newMethod(final SSymbol signature, final SSymbol returnType) {
     MethodBuilder builder = new MethodBuilder(peekObject(), probe);
     builder.setSignature(signature);
     builder.setReturnType(returnType);

--- a/src/som/compiler/SourceManager.java
+++ b/src/som/compiler/SourceManager.java
@@ -111,4 +111,15 @@ public class SourceManager {
     String firstArg = (String) language.getVM().getArguments()[0];
     return path.contains(firstArg);
   }
+
+  public boolean isBuiltInModule() {
+
+    String path = source.getURI().getPath();
+    for (String name : builtinModules) {
+      if (path.contains(name + ".grace")) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/src/som/compiler/Variable.java
+++ b/src/som/compiler/Variable.java
@@ -50,11 +50,11 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     }
   }
 
-  public final SSymbol           name;
-  public final SomStructuralType type;
-  public final SourceSection     source;
+  public final SSymbol       name;
+  public final SSymbol       type;
+  public final SourceSection source;
 
-  Variable(final SSymbol name, final SomStructuralType type, final SourceSection source) {
+  Variable(final SSymbol name, final SSymbol type, final SourceSection source) {
     this.name = name;
     this.type = type;
     this.source = source;
@@ -108,7 +108,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   public static final class Argument extends Variable {
     public final int index;
 
-    Argument(final SSymbol name, final SomStructuralType type, final int index,
+    Argument(final SSymbol name, final SSymbol type, final int index,
         final SourceSection source) {
       super(name, type, source);
       this.index = index;
@@ -186,7 +186,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   public abstract static class Local extends Variable {
     @CompilationFinal private FrameSlot slot;
 
-    Local(final SSymbol name, final SomStructuralType type, final SourceSection source) {
+    Local(final SSymbol name, final SSymbol type, final SourceSection source) {
       super(name, type, source);
     }
 
@@ -199,7 +199,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
       transferToInterpreterAndInvalidate("Variable.getReadNode");
       ExpressionNode node;
       if (contextLevel == 0) {
-        node = LocalVariableReadNodeGen.create(this, type);
+        node = LocalVariableReadNodeGen.create(this, SomStructuralType.recallTypeByName(type));
       } else {
         node = NonLocalVariableReadNodeGen.create(contextLevel, this);
       }
@@ -228,7 +228,8 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
       transferToInterpreterAndInvalidate("Variable.getWriteNode");
       ExpressionNode node;
       if (contextLevel == 0) {
-        node = LocalVariableWriteNodeGen.create(this, type, valueExpr);
+        node = LocalVariableWriteNodeGen.create(this, SomStructuralType.recallTypeByName(type),
+            valueExpr);
       } else {
         node = NonLocalVariableWriteNodeGen.create(contextLevel, this,
             valueExpr);
@@ -250,7 +251,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   }
 
   public static final class MutableLocal extends Local {
-    MutableLocal(final SSymbol name, final SomStructuralType type,
+    MutableLocal(final SSymbol name, final SSymbol type,
         final SourceSection source) {
       super(name, type, source);
     }
@@ -267,7 +268,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   }
 
   public static final class ImmutableLocal extends Local {
-    ImmutableLocal(final SSymbol name, final SomStructuralType type,
+    ImmutableLocal(final SSymbol name, final SSymbol type,
         final SourceSection source) {
       super(name, type, source);
     }

--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -6,15 +6,13 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
 import bd.inlining.ScopeAdaptationVisitor;
 import som.compiler.Variable.Local;
-import som.interpreter.nodes.dispatch.DispatchGuard;
-import som.interpreter.nodes.dispatch.DispatchGuard.AbstractTypeCheck;
+import som.interpreter.nodes.dispatch.TypeCheckNode;
+import som.interpreter.nodes.dispatch.TypeCheckNodeGen;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.vm.SomStructuralType;
-import som.vm.constants.KernelObj;
 import som.vm.constants.Nil;
 import som.vmobjects.SSymbol;
 import tools.Send;
@@ -27,13 +25,14 @@ public abstract class LocalVariableNode extends ExprWithTagsNode implements Send
   protected final FrameSlot         slot;
   protected final Local             var;
   protected final SomStructuralType type;
-  protected final AbstractTypeCheck check;
+
+  @Child protected TypeCheckNode typeCheck;
 
   private LocalVariableNode(final Local var, final SomStructuralType type) {
     this.slot = var.getSlot();
     this.var = var;
     this.type = type;
-    this.check = DispatchGuard.createTypeCheck(type);
+    this.typeCheck = type == null ? null : TypeCheckNodeGen.create(type, var.source);
   }
 
   public final Local getLocal() {
@@ -89,12 +88,8 @@ public abstract class LocalVariableNode extends ExprWithTagsNode implements Send
     @Specialization(guards = {"isBoolean(frame)"}, rewriteOn = {FrameSlotTypeException.class})
     public final boolean doBoolean(final VirtualFrame frame) throws FrameSlotTypeException {
       boolean ret = frame.getBoolean(slot);
-      try {
-        check.entryMatches(ret, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(ret);
       }
       return ret;
     }
@@ -102,12 +97,8 @@ public abstract class LocalVariableNode extends ExprWithTagsNode implements Send
     @Specialization(guards = {"isLong(frame)"}, rewriteOn = {FrameSlotTypeException.class})
     public final long doLong(final VirtualFrame frame) throws FrameSlotTypeException {
       long ret = frame.getLong(slot);
-      try {
-        check.entryMatches(ret, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(ret);
       }
       return ret;
     }
@@ -115,12 +106,8 @@ public abstract class LocalVariableNode extends ExprWithTagsNode implements Send
     @Specialization(guards = {"isDouble(frame)"}, rewriteOn = {FrameSlotTypeException.class})
     public final double doDouble(final VirtualFrame frame) throws FrameSlotTypeException {
       double ret = frame.getDouble(slot);
-      try {
-        check.entryMatches(ret, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(ret);
       }
       return ret;
     }
@@ -131,12 +118,8 @@ public abstract class LocalVariableNode extends ExprWithTagsNode implements Send
     public final Object doObject(final VirtualFrame frame)
         throws FrameSlotTypeException, IllegalArgumentException {
       Object ret = frame.getObject(slot);
-      try {
-        check.entryMatches(ret, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(ret);
       }
       return ret;
     }
@@ -181,54 +164,35 @@ public abstract class LocalVariableNode extends ExprWithTagsNode implements Send
 
     @Specialization(guards = "isBoolKind(expValue)")
     public final boolean writeBoolean(final VirtualFrame frame, final boolean expValue) {
-      try {
-        check.entryMatches(expValue, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(expValue);
       }
-
       frame.setBoolean(slot, expValue);
       return expValue;
     }
 
     @Specialization(guards = "isLongKind(expValue)")
     public final long writeLong(final VirtualFrame frame, final long expValue) {
-      try {
-        check.entryMatches(expValue, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(expValue);
       }
-
       frame.setLong(slot, expValue);
       return expValue;
     }
 
     @Specialization(guards = "isDoubleKind(expValue)")
     public final double writeDouble(final VirtualFrame frame, final double expValue) {
-      try {
-        check.entryMatches(expValue, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(expValue);
       }
-
       frame.setDouble(slot, expValue);
       return expValue;
     }
 
     @Specialization(replaces = {"writeBoolean", "writeLong", "writeDouble"})
     public final Object writeGeneric(final VirtualFrame frame, final Object expValue) {
-      try {
-        check.entryMatches(expValue, sourceSection);
-      } catch (IllegalArgumentException e) {
-        KernelObj.signalException("signalArgumentError:", e.getMessage());
-      } catch (InvalidAssumptionException e) {
-        throw new RuntimeException(e.getMessage());
+      if (typeCheck != null) {
+        typeCheck.executeTypeCheck(expValue);
       }
       slot.setKind(FrameSlotKind.Object);
       frame.setObject(slot, expValue);

--- a/src/som/interpreter/nodes/dispatch/CachedDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/CachedDispatchNode.java
@@ -38,7 +38,6 @@ public final class CachedDispatchNode extends AbstractDispatchNode {
   }
 
   @Override
-  @ExplodeLoop
   public Object executeDispatch(final Object[] arguments) {
     performTypeChecks(arguments);
 
@@ -69,6 +68,7 @@ public final class CachedDispatchNode extends AbstractDispatchNode {
     }
   }
 
+  @ExplodeLoop
   private void performTypeChecks(final Object[] arguments) {
     if (!VmSettings.USE_TYPE_CHECKING) {
       return;

--- a/src/som/interpreter/nodes/dispatch/CachedSlotRead.java
+++ b/src/som/interpreter/nodes/dispatch/CachedSlotRead.java
@@ -4,9 +4,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.profiles.IntValueProfile;
 
-import som.interpreter.nodes.dispatch.DispatchGuard.AbstractTypeCheck;
 import som.interpreter.nodes.dispatch.DispatchGuard.CheckSObject;
-import som.interpreter.nodes.dispatch.DispatchGuard.StructuralTypeCheck;
 import som.interpreter.objectstorage.StorageAccessor.AbstractObjectAccessor;
 import som.interpreter.objectstorage.StorageAccessor.AbstractPrimitiveAccessor;
 import som.vm.constants.Nil;
@@ -29,17 +27,17 @@ import tools.dym.Tags.FieldRead;
  */
 public abstract class CachedSlotRead extends AbstractDispatchNode {
   @Child protected AbstractDispatchNode nextInCache;
+  @Child protected TypeCheckNode        typeCheck;
 
-  protected final CheckSObject      guardForRcvr;
-  protected final AbstractTypeCheck guardForType;
-  protected final SlotAccess        type;
+  protected final CheckSObject guardForRcvr;
+  protected final SlotAccess   type;
 
   public CachedSlotRead(final SlotAccess type, final CheckSObject guardForRcvr,
-      final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
+      final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
     super(nextInCache.sourceSection);
     this.type = type;
     this.guardForRcvr = guardForRcvr;
-    this.guardForType = guardForType;
+    this.typeCheck = typeCheck;
     this.nextInCache = nextInCache;
     assert nextInCache != null;
   }
@@ -83,8 +81,8 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
   public static final class UnwrittenSlotRead extends CachedSlotRead {
 
     public UnwrittenSlotRead(final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
-      super(type, guardForRcvr, guardForType, nextInCache);
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
+      super(type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
@@ -98,8 +96,8 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
 
     public ObjectSlotRead(final AbstractObjectAccessor accessor,
         final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
-      super(type, guardForRcvr, guardForType, nextInCache);
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
+      super(type, guardForRcvr, typeCheck, nextInCache);
       this.accessor = accessor;
     }
 
@@ -114,9 +112,9 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
     protected final IntValueProfile           primMarkProfile;
 
     PrimSlotRead(final AbstractPrimitiveAccessor accessor, final SlotAccess type,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode nextInCache) {
-      super(type, guardForRcvr, guardForType, nextInCache);
+      super(type, guardForRcvr, typeCheck, nextInCache);
       this.accessor = accessor;
       this.primMarkProfile = IntValueProfile.createIdentityProfile();
     }
@@ -126,8 +124,8 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
 
     public LongSlotReadSetOrUnset(final AbstractPrimitiveAccessor accessor,
         final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
-      super(accessor, type, guardForRcvr, guardForType, nextInCache);
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
+      super(accessor, type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
@@ -143,9 +141,9 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
   public static final class LongSlotReadSet extends PrimSlotRead {
 
     public LongSlotReadSet(final AbstractPrimitiveAccessor accessor, final SlotAccess type,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode nextInCache) {
-      super(accessor, type, guardForRcvr, guardForType, nextInCache);
+      super(accessor, type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
@@ -154,7 +152,7 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
         return accessor.readLong(rcvr);
       } else {
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        replace(new LongSlotReadSetOrUnset(accessor, type, guardForRcvr, guardForType,
+        replace(new LongSlotReadSetOrUnset(accessor, type, guardForRcvr, typeCheck,
             nextInCache));
         return Nil.nilObject;
       }
@@ -165,8 +163,8 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
 
     public DoubleSlotReadSetOrUnset(final AbstractPrimitiveAccessor accessor,
         final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
-      super(accessor, type, guardForRcvr, guardForType, nextInCache);
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
+      super(accessor, type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
@@ -183,8 +181,8 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
 
     public DoubleSlotReadSet(final AbstractPrimitiveAccessor accessor,
         final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
-      super(accessor, type, guardForRcvr, guardForType, nextInCache);
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
+      super(accessor, type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
@@ -193,7 +191,7 @@ public abstract class CachedSlotRead extends AbstractDispatchNode {
         return accessor.readDouble(rcvr);
       } else {
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        replace(new DoubleSlotReadSetOrUnset(accessor, type, guardForRcvr, guardForType,
+        replace(new DoubleSlotReadSetOrUnset(accessor, type, guardForRcvr, typeCheck,
             nextInCache));
         return Nil.nilObject;
       }

--- a/src/som/interpreter/nodes/dispatch/ClassSlotAccessNode.java
+++ b/src/som/interpreter/nodes/dispatch/ClassSlotAccessNode.java
@@ -38,7 +38,7 @@ public final class ClassSlotAccessNode extends CachedSlotRead {
 
   public ClassSlotAccessNode(final MixinDefinition mixinDef, final SlotDefinition slotDef,
       final CachedSlotRead read, final CachedSlotWrite write) {
-    super(SlotAccess.CLASS_READ, read.guardForRcvr, read.guardForType, read.nextInCache);
+    super(SlotAccess.CLASS_READ, read.guardForRcvr, read.typeCheck, read.nextInCache);
 
     // TODO: can the slot read be an unwritten read? I'd think so.
     this.read = read;

--- a/src/som/interpreter/nodes/dispatch/DispatchGuard.java
+++ b/src/som/interpreter/nodes/dispatch/DispatchGuard.java
@@ -10,6 +10,7 @@ import som.interpreter.Types;
 import som.interpreter.objectstorage.ClassFactory;
 import som.interpreter.objectstorage.ObjectLayout;
 import som.vm.SomStructuralType;
+import som.vm.constants.Nil;
 import som.vmobjects.SClass;
 import som.vmobjects.SObject;
 import som.vmobjects.SObject.SImmutableObject;
@@ -272,6 +273,10 @@ public abstract class DispatchGuard {
     @Override
     public boolean entryMatches(final Object obj, final SourceSection sourceSection)
         throws InvalidAssumptionException, IllegalArgumentException {
+
+      if (obj == Nil.nilObject) {
+        return true;
+      }
 
       MixinDefinition mixinDef;
       if (obj instanceof SObjectWithClass) {

--- a/src/som/interpreter/nodes/dispatch/DispatchGuard.java
+++ b/src/som/interpreter/nodes/dispatch/DispatchGuard.java
@@ -1,21 +1,14 @@
 package som.interpreter.nodes.dispatch;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.source.SourceSection;
 
-import som.compiler.MixinBuilder.MixinDefinitionId;
-import som.compiler.MixinDefinition;
-import som.interpreter.Types;
 import som.interpreter.objectstorage.ClassFactory;
 import som.interpreter.objectstorage.ObjectLayout;
-import som.vm.SomStructuralType;
-import som.vm.constants.Nil;
 import som.vmobjects.SClass;
 import som.vmobjects.SObject;
 import som.vmobjects.SObject.SImmutableObject;
 import som.vmobjects.SObject.SMutableObject;
-import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 
 
@@ -59,27 +52,6 @@ public abstract class DispatchGuard {
 
     assert obj instanceof SImmutableObject;
     return new CheckSImmutableObject(((SImmutableObject) obj).getObjectLayout());
-  }
-
-  /**
-   * Creates an appropriate type-checking dispatch guard. The expected type may be null (used
-   * for "unknown" types), and in this case we simply create a no-operation type checking
-   * guard. This is done so that every argument always has a corresponding guard, which
-   * simplifies the implementation of the loop used to run these guards against their
-   * arguments. If the guard is a primitive - a boolean, number, or string - we create a
-   * primitive type-checking guard that implements a simple "instance of" check. And finally,
-   * if we are given a proper SOM object, we create a full structural type-checking guard.
-   */
-  public static AbstractTypeCheck createTypeCheck(final SomStructuralType expectedType) {
-    if (expectedType == null) {
-      return new NoTypeCheck();
-    } else {
-      return new StructuralTypeCheck(expectedType);
-    }
-  }
-
-  public boolean ignore() {
-    return false;
   }
 
   private static final class CheckClass extends DispatchGuard {
@@ -190,124 +162,6 @@ public abstract class DispatchGuard {
     @Override
     public SObject cast(final Object obj) {
       return (SImmutableObject) obj;
-    }
-  }
-
-  public static abstract class AbstractTypeCheck extends DispatchGuard {
-
-    protected void throwTypeError(final Object obj, final SomStructuralType expected,
-        final SourceSection sourceSection) throws IllegalArgumentException {
-      CompilerDirectives.transferToInterpreter();
-      String prefix = "";
-      if (sourceSection != null) {
-        prefix =
-            "[" + sourceSection.getStartLine() + "," + sourceSection.getStartColumn() + "]";
-      }
-
-      SomStructuralType objType;
-      if (obj instanceof SObjectWithClass) {
-        objType = SomStructuralType.getTypeFromMixin(
-            ((SObjectWithClass) obj).getSOMClass().getMixinDefinition());
-      } else {
-        objType =
-            SomStructuralType.getTypeFromMixin(Types.getClassOf(obj).getMixinDefinition());
-      }
-      throw new IllegalArgumentException(
-          prefix + " " + objType + " does not implemenet the interface " + expected);
-    }
-
-  }
-
-  public static final class NoTypeCheck extends AbstractTypeCheck {
-    @Override
-    public boolean entryMatches(final Object obj, final SourceSection sourceSection)
-        throws InvalidAssumptionException {
-      return true;
-    }
-  }
-
-  /**
-   * This guard is responsible for determining whether the given argument conforms to the given
-   * structural type. Note that the {@link StructuralTypeCheck} is responsible for conducting
-   * the type conformity check itself.
-   *
-   * For efficiency, we perform the structural type check only, during the initialization of
-   * this guard. We cache the result after it has been calculated, indexed by the SClass. For
-   * the next call we simply examine the given argument; if the class is the same then we
-   * assume the result will be the same as was computed previously and simply return true, or
-   * otherwise, we invoke the {@link IllegalArgumentException} error.
-   *
-   * Note that the argument error may be caught by a SOM block and, therefore, we must throw
-   * the error during execution rather than initialization.
-   *
-   */
-  public static final class StructuralTypeCheck extends AbstractTypeCheck {
-
-    private final SomStructuralType   expected;
-    private final MixinDefinitionId[] cacheIds;
-    private final boolean[]           cacheResults;
-    private final int                 cacheSize;
-    private int                       nCached = 0;
-
-    StructuralTypeCheck(final SomStructuralType structuralType, final int cacheSize) {
-      this.expected = structuralType;
-      this.cacheSize = cacheSize;
-      this.cacheIds = new MixinDefinitionId[cacheSize];
-      this.cacheResults = new boolean[cacheSize];
-    }
-
-    public StructuralTypeCheck(final SomStructuralType structuralType) {
-      this(structuralType, 10);
-    }
-
-    public boolean doTypeCheckOnSlowPath(final MixinDefinition mixinDef) {
-      CompilerDirectives.transferToInterpreter();
-      SomStructuralType objType = mixinDef.getType();
-      boolean ret = (objType.isSubclassOf(expected));
-      cacheIds[nCached] = mixinDef.getMixinId();
-      cacheResults[nCached] = ret;
-      nCached += 1;
-      return ret;
-    }
-
-    @Override
-    public boolean entryMatches(final Object obj, final SourceSection sourceSection)
-        throws InvalidAssumptionException, IllegalArgumentException {
-
-      if (obj == Nil.nilObject) {
-        return true;
-      }
-
-      MixinDefinition mixinDef;
-      if (obj instanceof SObjectWithClass) {
-        mixinDef = ((SObjectWithClass) obj).getSOMClass().getMixinDefinition();
-      } else {
-        mixinDef = Types.getClassOf(obj).getMixinDefinition();
-      }
-
-      MixinDefinitionId id = mixinDef.getMixinId();
-      for (int i = 0; i < cacheSize; i++) {
-        if (id == cacheIds[i]) {
-          if (cacheResults[i]) {
-            return true;
-          } else {
-            throwTypeError(obj, expected, sourceSection);
-            return false;
-          }
-        }
-      }
-
-      if (doTypeCheckOnSlowPath(mixinDef)) {
-        return true;
-      } else {
-        throwTypeError(obj, expected, sourceSection);
-        return false;
-      }
-    }
-
-    @Override
-    public boolean ignore() {
-      return expected == null;
     }
   }
 }

--- a/src/som/interpreter/nodes/dispatch/TypeCheckNode.java
+++ b/src/som/interpreter/nodes/dispatch/TypeCheckNode.java
@@ -1,0 +1,119 @@
+package som.interpreter.nodes.dispatch;
+
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.Types;
+import som.interpreter.objectstorage.ClassFactory;
+import som.interpreter.objectstorage.ObjectLayout;
+import som.vm.SomStructuralType;
+import som.vm.constants.KernelObj;
+import som.vm.constants.Nil;
+import som.vmobjects.SArray;
+import som.vmobjects.SObject;
+import som.vmobjects.SObjectWithClass;
+import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
+
+
+public abstract class TypeCheckNode extends Node {
+
+  @CompilationFinal SomStructuralType expected;
+  @CompilationFinal SourceSection     sourceSection;
+
+  TypeCheckNode(final SomStructuralType expected, final SourceSection sourceSection) {
+    this.expected = expected;
+    this.sourceSection = sourceSection;
+  }
+
+  private void throwTypeError(final Object obj) {
+    CompilerDirectives.transferToInterpreter();
+    int line = sourceSection.getStartLine();
+    int column = sourceSection.getStartColumn();
+    String suffix = "[" + line + "," + column + "]";
+    KernelObj.signalException("signalTypeError:",
+        suffix + " " + obj + " is not a subclass of " + expected);
+  }
+
+  protected boolean isNil(final Object obj) {
+    return obj == Nil.nilObject;
+  }
+
+  protected ClassFactory getFactoryForPrimitive(final Object obj) {
+    return Types.getClassOf(obj).getFactory();
+  }
+
+  @Specialization(guards = {"isNil(obj)"})
+  public void performTypeCheckOnNil(final Object obj) {
+    // no op
+  }
+
+  @Specialization(guards = {"cachedFactory.getType().isSubclassOf(expected)"})
+  public void performTypeCheckOnBoolean(final boolean obj,
+      @Cached("getFactoryForPrimitive(obj)") final ClassFactory cachedFactory) {
+    // no op
+  }
+
+  @Specialization(guards = {"cachedFactory.getType().isSubclassOf(expected)"})
+  public void performTypeCheckOnLong(final long obj,
+      @Cached("getFactoryForPrimitive(obj)") final ClassFactory cachedFactory) {
+    // no op
+  }
+
+  @Specialization(guards = {"cachedFactory.getType().isSubclassOf(expected)"})
+  public void performTypeCheckOnDouble(final double obj,
+      @Cached("getFactoryForPrimitive(obj)") final ClassFactory cachedFactory) {
+    // no op
+  }
+
+  @Specialization(guards = {"cachedFactory.getType().isSubclassOf(expected)"})
+  public void performTypeCheckOnString(final String obj,
+      @Cached("getFactoryForPrimitive(obj)") final ClassFactory cachedFactory) {
+    // no op
+  }
+
+  @Specialization(guards = {"cachedFactory.getType().isSubclassOf(expected)"})
+  public void performTypeCheckOnString(final SArray obj,
+      @Cached("getFactoryForPrimitive(obj)") final ClassFactory cachedFactory) {
+    // no op
+  }
+
+  @Specialization(guards = {"obj.getFactory() == cachedFactory",
+      "cachedFactory.getType().isSubclassOf(expected)"}, limit = "3")
+  public void checkObject(final SObjectWithoutFields obj,
+      @Cached("obj.getFactory()") final ClassFactory cachedFactory) {
+    // no op
+  }
+
+  @Specialization(guards = {"obj.getObjectLayout() == cachedLayout",
+      "cachedFactory.getType().isSubclassOf(expected)"}, limit = "3")
+  public void checkObject(final SObject obj,
+      @Cached("obj.getFactory()") final ClassFactory cachedFactory,
+      @Cached("obj.getObjectLayout()") final ObjectLayout cachedLayout) {
+    // no op
+  }
+
+  @Specialization(replaces = "checkObject")
+  public void checkObject(final SObjectWithClass obj) {
+    CompilerAsserts.neverPartOfCompilation(
+        "This specialization should not be part of our benchmark execution. If it is, figure out why");
+    if (obj.getFactory().getType().isSubclassOf(expected)) {
+      // no op
+    } else {
+      CompilerDirectives.transferToInterpreter();
+      throwTypeError(obj);
+    }
+  }
+
+  @Fallback
+  public void typeCheckFailed(final Object obj) {
+    throwTypeError(obj);
+  }
+
+  public abstract void executeTypeCheck(final Object obj);
+}

--- a/src/som/interpreter/nodes/dispatch/TypeCheckNode.java
+++ b/src/som/interpreter/nodes/dispatch/TypeCheckNode.java
@@ -13,6 +13,7 @@ import som.interpreter.Types;
 import som.interpreter.objectstorage.ClassFactory;
 import som.interpreter.objectstorage.ObjectLayout;
 import som.vm.SomStructuralType;
+import som.vm.VmSettings;
 import som.vm.constants.KernelObj;
 import som.vm.constants.Nil;
 import som.vmobjects.SArray;
@@ -29,6 +30,7 @@ public abstract class TypeCheckNode extends Node {
   @CompilationFinal SourceSection     sourceSection;
 
   TypeCheckNode(final SomStructuralType expected, final SourceSection sourceSection) {
+    assert VmSettings.USE_TYPE_CHECKING : "Trying to create a TypeCheckNode, while USE_TYPE_CHECKING is disabled";
     this.expected = expected;
     this.sourceSection = sourceSection;
   }

--- a/src/som/interpreter/nodes/dispatch/TypeCheckNode.java
+++ b/src/som/interpreter/nodes/dispatch/TypeCheckNode.java
@@ -35,13 +35,15 @@ public abstract class TypeCheckNode extends Node {
     this.sourceSection = sourceSection;
   }
 
-  private void throwTypeError(final Object obj) {
+  private void throwTypeError(final Object obj, final SomStructuralType actualType) {
     CompilerDirectives.transferToInterpreter();
     int line = sourceSection.getStartLine();
     int column = sourceSection.getStartColumn();
-    String suffix = "[" + line + "," + column + "]";
+    String[] parts = sourceSection.getSource().getURI().getPath().split("/");
+    String suffix = parts[parts.length - 1] + " [" + line + "," + column + "]";
     KernelObj.signalException("signalTypeError:",
-        suffix + " " + obj + " is not a subclass of " + expected);
+        suffix + " " + obj + " is not a subclass of " + expected + ", because it has the type "
+            + actualType);
   }
 
   protected boolean isNil(final SObjectWithoutFields obj) {
@@ -129,7 +131,7 @@ public abstract class TypeCheckNode extends Node {
 
   @Fallback
   public void typeCheckFailed(final Object obj) {
-    throwTypeError(obj);
+    throwTypeError(obj, null);
   }
 
   public abstract void executeTypeCheck(final Object obj);

--- a/src/som/interpreter/nodes/literals/BlockNode.java
+++ b/src/som/interpreter/nodes/literals/BlockNode.java
@@ -74,7 +74,7 @@ public class BlockNode extends LiteralNode {
         inliner.outerScopeChanged());
     SInvokable adaptedIvk = new SInvokable(blockMethod.getSignature(),
         AccessModifier.BLOCK_METHOD,
-        adapted, blockMethod.getEmbeddedBlocks(), new SomStructuralType[] {});
+        adapted, blockMethod.getEmbeddedBlocks(), new SomStructuralType[] {null});
     replace(createNode(adaptedIvk));
   }
 

--- a/src/som/interpreter/objectstorage/ClassFactory.java
+++ b/src/som/interpreter/objectstorage/ClassFactory.java
@@ -14,6 +14,7 @@ import som.compiler.MixinDefinition;
 import som.compiler.MixinDefinition.SlotDefinition;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.vm.SomStructuralType;
+import som.vm.VmSettings;
 import som.vmobjects.SClass;
 import som.vmobjects.SSymbol;
 
@@ -192,6 +193,10 @@ public final class ClassFactory {
   }
 
   private SomStructuralType getType() {
+    if (!VmSettings.USE_TYPE_CHECKING) {
+      return null;
+    }
+
     List<SSymbol> signatures = new ArrayList<SSymbol>();
 
     EconomicMap<SSymbol, Dispatchable> dispatchables = mixinDef.getInstanceDispatchables();

--- a/src/som/interpreter/objectstorage/StorageLocation.java
+++ b/src/som/interpreter/objectstorage/StorageLocation.java
@@ -20,8 +20,8 @@ import som.interpreter.nodes.dispatch.CachedSlotWrite.LongSlotWriteSet;
 import som.interpreter.nodes.dispatch.CachedSlotWrite.LongSlotWriteSetOrUnset;
 import som.interpreter.nodes.dispatch.CachedSlotWrite.ObjectSlotWrite;
 import som.interpreter.nodes.dispatch.CachedSlotWrite.UnwrittenSlotWrite;
-import som.interpreter.nodes.dispatch.DispatchGuard.AbstractTypeCheck;
 import som.interpreter.nodes.dispatch.DispatchGuard.CheckSObject;
+import som.interpreter.nodes.dispatch.TypeCheckNode;
 import som.interpreter.objectstorage.StorageAccessor.AbstractObjectAccessor;
 import som.interpreter.objectstorage.StorageAccessor.AbstractPrimitiveAccessor;
 import som.vm.constants.Nil;
@@ -72,10 +72,10 @@ public abstract class StorageLocation {
   public abstract boolean isObjectLocation();
 
   public abstract CachedSlotRead getReadNode(SlotAccess type, CheckSObject guardForRcvr,
-      AbstractTypeCheck guardForType, AbstractDispatchNode nextInCache, boolean isSet);
+      TypeCheckNode typeCheck, AbstractDispatchNode nextInCache, boolean isSet);
 
   public abstract CachedSlotWrite getWriteNode(SlotDefinition slot, CheckSObject guardForRcvr,
-      AbstractTypeCheck guardForType, AbstractDispatchNode next, boolean isSet);
+      TypeCheckNode typeCheck, AbstractDispatchNode next, boolean isSet);
 
   public abstract StorageAccessor getAccessor();
 
@@ -113,16 +113,16 @@ public abstract class StorageLocation {
 
     @Override
     public CachedSlotRead getReadNode(final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache,
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache,
         final boolean isSet) {
-      return new UnwrittenSlotRead(type, guardForRcvr, guardForType, nextInCache);
+      return new UnwrittenSlotRead(type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
     public CachedSlotWrite getWriteNode(final SlotDefinition slot,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode next, final boolean isSet) {
-      return new UnwrittenSlotWrite(slot, guardForRcvr, guardForType, next);
+      return new UnwrittenSlotWrite(slot, guardForRcvr, typeCheck, next);
     }
 
     /**
@@ -174,16 +174,16 @@ public abstract class StorageLocation {
      */
     @Override
     public CachedSlotRead getReadNode(final SlotAccess type, final CheckSObject guardForRcvr,
-        final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache,
+        final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache,
         final boolean isSet) {
-      return new ObjectSlotRead(accessor, type, guardForRcvr, guardForType, nextInCache);
+      return new ObjectSlotRead(accessor, type, guardForRcvr, typeCheck, nextInCache);
     }
 
     @Override
     public CachedSlotWrite getWriteNode(final SlotDefinition slot,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode next, final boolean isSet) {
-      return new ObjectSlotWrite(accessor, guardForRcvr, guardForType, next);
+      return new ObjectSlotWrite(accessor, guardForRcvr, typeCheck, next);
     }
 
     /**
@@ -257,25 +257,25 @@ public abstract class StorageLocation {
 
     @Override
     public CachedSlotRead getReadNode(final SlotAccess type,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode nextInCache,
         final boolean isSet) {
       if (isSet) {
-        return new LongSlotReadSet(accessor, type, guardForRcvr, guardForType, nextInCache);
+        return new LongSlotReadSet(accessor, type, guardForRcvr, typeCheck, nextInCache);
       } else {
-        return new LongSlotReadSetOrUnset(accessor, type, guardForRcvr, guardForType,
+        return new LongSlotReadSetOrUnset(accessor, type, guardForRcvr, typeCheck,
             nextInCache);
       }
     }
 
     @Override
     public CachedSlotWrite getWriteNode(final SlotDefinition slot,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode next, final boolean isSet) {
       if (isSet) {
-        return new LongSlotWriteSet(slot, accessor, guardForRcvr, guardForType, next);
+        return new LongSlotWriteSet(slot, accessor, guardForRcvr, typeCheck, next);
       } else {
-        return new LongSlotWriteSetOrUnset(slot, accessor, guardForRcvr, guardForType, next);
+        return new LongSlotWriteSetOrUnset(slot, accessor, guardForRcvr, typeCheck, next);
       }
     }
 
@@ -318,24 +318,24 @@ public abstract class StorageLocation {
 
     @Override
     public CachedSlotRead getReadNode(final SlotAccess type,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode nextInCache, final boolean isSet) {
       if (isSet) {
-        return new DoubleSlotReadSet(accessor, type, guardForRcvr, guardForType, nextInCache);
+        return new DoubleSlotReadSet(accessor, type, guardForRcvr, typeCheck, nextInCache);
       } else {
-        return new DoubleSlotReadSetOrUnset(accessor, type, guardForRcvr, guardForType,
+        return new DoubleSlotReadSetOrUnset(accessor, type, guardForRcvr, typeCheck,
             nextInCache);
       }
     }
 
     @Override
     public CachedSlotWrite getWriteNode(final SlotDefinition slot,
-        final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+        final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
         final AbstractDispatchNode next, final boolean isSet) {
       if (isSet) {
-        return new DoubleSlotWriteSet(slot, accessor, guardForRcvr, guardForType, next);
+        return new DoubleSlotWriteSet(slot, accessor, guardForRcvr, typeCheck, next);
       } else {
-        return new DoubleSlotWriteSetOrUnset(slot, accessor, guardForRcvr, guardForType, next);
+        return new DoubleSlotWriteSetOrUnset(slot, accessor, guardForRcvr, typeCheck, next);
       }
     }
 

--- a/src/som/interpreter/transactions/CachedTxSlotRead.java
+++ b/src/som/interpreter/transactions/CachedTxSlotRead.java
@@ -2,8 +2,8 @@ package som.interpreter.transactions;
 
 import som.interpreter.nodes.dispatch.AbstractDispatchNode;
 import som.interpreter.nodes.dispatch.CachedSlotRead;
-import som.interpreter.nodes.dispatch.DispatchGuard.AbstractTypeCheck;
 import som.interpreter.nodes.dispatch.DispatchGuard.CheckSObject;
+import som.interpreter.nodes.dispatch.TypeCheckNode;
 import som.vmobjects.SObject;
 import som.vmobjects.SObject.SMutableObject;
 
@@ -12,9 +12,9 @@ public final class CachedTxSlotRead extends CachedSlotRead {
   @Child protected CachedSlotRead read;
 
   public CachedTxSlotRead(final SlotAccess type, final CachedSlotRead read,
-      final CheckSObject guardForRcvr, final AbstractTypeCheck guardForType,
+      final CheckSObject guardForRcvr, final TypeCheckNode typeCheck,
       final AbstractDispatchNode nextInCache) {
-    super(type, guardForRcvr, guardForType, nextInCache);
+    super(type, guardForRcvr, typeCheck, nextInCache);
     assert type == SlotAccess.FIELD_READ;
     this.read = read;
   }

--- a/src/som/interpreter/transactions/CachedTxSlotWrite.java
+++ b/src/som/interpreter/transactions/CachedTxSlotWrite.java
@@ -2,8 +2,8 @@ package som.interpreter.transactions;
 
 import som.interpreter.nodes.dispatch.AbstractDispatchNode;
 import som.interpreter.nodes.dispatch.CachedSlotWrite;
-import som.interpreter.nodes.dispatch.DispatchGuard.AbstractTypeCheck;
 import som.interpreter.nodes.dispatch.DispatchGuard.CheckSObject;
+import som.interpreter.nodes.dispatch.TypeCheckNode;
 import som.vmobjects.SObject;
 import som.vmobjects.SObject.SMutableObject;
 
@@ -12,8 +12,8 @@ public final class CachedTxSlotWrite extends CachedSlotWrite {
   @Child protected CachedSlotWrite write;
 
   public CachedTxSlotWrite(final CachedSlotWrite write, final CheckSObject guardForRcvr,
-      final AbstractTypeCheck guardForType, final AbstractDispatchNode nextInCache) {
-    super(guardForRcvr, guardForType, nextInCache);
+      final TypeCheckNode typeCheck, final AbstractDispatchNode nextInCache) {
+    super(guardForRcvr, typeCheck, nextInCache);
     this.write = write;
   }
 

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -144,7 +144,7 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
         prim.getScope().getFrameDescriptor(),
         (ExpressionNode) primNode.deepCopy(), false, lang);
     return new SInvokable(signature, AccessModifier.PUBLIC,
-        primMethodNode, null, new SomStructuralType[] {});
+        primMethodNode, null, new SomStructuralType[] {null});
   }
 
   public EconomicMap<SSymbol, Dispatchable> takeVmMirrorPrimitives() {

--- a/src/som/vm/SomStructuralType.java
+++ b/src/som/vm/SomStructuralType.java
@@ -159,6 +159,10 @@ public class SomStructuralType {
     return recordedTypes.get(symbolFor(name));
   }
 
+  public static boolean isNullOrUnknown(final SSymbol identifier) {
+    return identifier == null || identifier == UNKNOWN;
+  }
+
   @Override
   public String toString() {
     List<SSymbol> typeElements = Arrays.asList(signatures);

--- a/src/som/vm/SomStructuralType.java
+++ b/src/som/vm/SomStructuralType.java
@@ -76,6 +76,8 @@ public class SomStructuralType {
   @CompilationFinal private final int tableIndex;
 
   private SomStructuralType(final List<SSymbol> signatures) {
+    assert VmSettings.USE_TYPE_CHECKING : "SomStructuralType is created dispited USE_TYPE_CHECKING not being enabled";
+
     this.signatures = signatures.toArray(new SSymbol[signatures.size()]);
     this.tableIndex = nTypes;
     nTypes += 1;
@@ -143,6 +145,9 @@ public class SomStructuralType {
   }
 
   public static SomStructuralType recallTypeByName(final SSymbol name) {
+    if (!VmSettings.USE_TYPE_CHECKING || name == null || name == SomStructuralType.UNKNOWN) {
+      return null;
+    }
     if (!recordedTypes.containsKey(name)) {
       throw new RuntimeException(
           "No type is known under the name `" + name.getString() + "`");

--- a/src/som/vm/SomStructuralType.java
+++ b/src/som/vm/SomStructuralType.java
@@ -161,8 +161,11 @@ public class SomStructuralType {
 
   @Override
   public String toString() {
+    List<SSymbol> typeElements = Arrays.asList(signatures);
+    typeElements.sort((a, b) -> a.getString().compareTo(b.getString()));
+
     String s = "{ ";
-    for (SSymbol sig : signatures) {
+    for (SSymbol sig : typeElements) {
       s += " " + sig.getString() + ",";
     }
     s += " }";

--- a/src/som/vm/SomStructuralType.java
+++ b/src/som/vm/SomStructuralType.java
@@ -92,6 +92,28 @@ public class SomStructuralType {
         }
       }
       if (!found) {
+        return SUBCLASS_STATE.NOT_SUBCLASS;
+      }
+    }
+
+    return SUBCLASS_STATE.IS_SUBCLASS;
+  }
+
+  public boolean isSubclassOf(final SomStructuralType other) {
+    CompilerAsserts.neverPartOfCompilation();
+
+    if (other == null || Nil.nilObject.getFactory().type == other) {
+      return true;
+    }
+
+    SUBCLASS_STATE state = subtypingTable[other.tableIndex][this.tableIndex];
+    if (state == null) {
+      subtypingTable[other.tableIndex][this.tableIndex] = checkSignatures(other);
+      return isSubclassOf(other);
+    } else {
+      if (state == SUBCLASS_STATE.IS_SUBCLASS) {
+        return true;
+      } else {
         return false;
       }
     }

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -33,6 +33,8 @@ public class VmSettings implements Settings {
 
   public static final boolean USE_TYPE_CHECKING;
 
+  public static final boolean MUST_BE_FULLY_TYPED;
+
   public static final String INSTRUMENTATION_PROP = "som.instrumentation";
 
   static {
@@ -77,6 +79,7 @@ public class VmSettings implements Settings {
     ANSI_COLOR_IN_OUTPUT = getBool("som.useAnsiColoring", false);
 
     USE_TYPE_CHECKING = getBool("som.useTypeChecking", false);
+    MUST_BE_FULLY_TYPED = getBool("som.ensureFullyTyped", false);
   }
 
   private static boolean getBool(final String prop, final boolean defaultVal) {

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -31,6 +31,8 @@ public class VmSettings implements Settings {
 
   public static final boolean ANSI_COLOR_IN_OUTPUT;
 
+  public static final boolean USE_TYPE_CHECKING;
+
   public static final String INSTRUMENTATION_PROP = "som.instrumentation";
 
   static {
@@ -73,6 +75,8 @@ public class VmSettings implements Settings {
     IGV_DUMP_AFTER_PARSING = getBool("som.igvDumpAfterParsing", false);
 
     ANSI_COLOR_IN_OUTPUT = getBool("som.useAnsiColoring", false);
+
+    USE_TYPE_CHECKING = getBool("som.useTypeChecking", false);
   }
 
   private static boolean getBool(final String prop, final boolean defaultVal) {

--- a/src/som/vmobjects/SInvokable.java
+++ b/src/som/vmobjects/SInvokable.java
@@ -45,6 +45,8 @@ import som.interpreter.nodes.dispatch.CachedDispatchNode;
 import som.interpreter.nodes.dispatch.DispatchGuard;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.interpreter.nodes.dispatch.LexicallyBoundDispatchNode;
+import som.interpreter.nodes.dispatch.TypeCheckNode;
+import som.interpreter.nodes.dispatch.TypeCheckNodeGen;
 import som.vm.SomStructuralType;
 import som.vm.constants.Classes;
 
@@ -201,14 +203,19 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
       return new LexicallyBoundDispatchNode(next.getSourceSection(), ct);
     }
 
-    List<DispatchGuard> guards = new ArrayList<DispatchGuard>();
-    guards.add(DispatchGuard.create(rcvr)); // receiver guard
+    List<TypeCheckNode> types = new ArrayList<TypeCheckNode>();
     for (int i = 0; i < expectedTypes.length; i++) {
       SomStructuralType expectedType = expectedTypes[i];
-      guards.add(DispatchGuard.createTypeCheck(expectedType));
+      if (expectedType == null) {
+        types.add(null);
+      } else {
+        types.add(TypeCheckNodeGen.create(expectedType, getSourceSection()));
+      }
+
     }
 
-    return new CachedDispatchNode(ct, guards.toArray(new DispatchGuard[guards.size()]), next);
+    return new CachedDispatchNode(ct, DispatchGuard.create(rcvr),
+        types.toArray(new TypeCheckNode[types.size()]), next);
   }
 
   @Override

--- a/src/som/vmobjects/SInvokable.java
+++ b/src/som/vmobjects/SInvokable.java
@@ -48,6 +48,7 @@ import som.interpreter.nodes.dispatch.LexicallyBoundDispatchNode;
 import som.interpreter.nodes.dispatch.TypeCheckNode;
 import som.interpreter.nodes.dispatch.TypeCheckNodeGen;
 import som.vm.SomStructuralType;
+import som.vm.VmSettings;
 import som.vm.constants.Classes;
 
 
@@ -203,6 +204,16 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
       return new LexicallyBoundDispatchNode(next.getSourceSection(), ct);
     }
 
+    TypeCheckNode[] typeCheckNodes = createTypeCheckNodes();
+
+    return new CachedDispatchNode(ct, DispatchGuard.create(rcvr),
+        typeCheckNodes, next);
+  }
+
+  private TypeCheckNode[] createTypeCheckNodes() {
+    if (!VmSettings.USE_TYPE_CHECKING) {
+      return null;
+    }
     List<TypeCheckNode> types = new ArrayList<TypeCheckNode>();
     for (int i = 0; i < expectedTypes.length; i++) {
       SomStructuralType expectedType = expectedTypes[i];
@@ -211,11 +222,10 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
       } else {
         types.add(TypeCheckNodeGen.create(expectedType, getSourceSection()));
       }
-
     }
 
-    return new CachedDispatchNode(ct, DispatchGuard.create(rcvr),
-        types.toArray(new TypeCheckNode[types.size()]), next);
+    TypeCheckNode[] typeCheckNodes = types.toArray(new TypeCheckNode[types.size()]);
+    return typeCheckNodes;
   }
 
   @Override


### PR DESCRIPTION
Here we simplify and optimize Moth's support for shallow type checking. 

Most importantly the type checking logic can be turned on by executing Moth with the `-tc` argument. When the argument is omitted, thus the default, any behaviour related to type checking will not be performed.  

We have moved the responsibility of creating the expected types out of the parser, which now only records the name of the expected type, and into the `ClassFactory` (which creates types by enumerating the names of its dispatches, including those belonging to superclasses).  

We have also introduced a new AST node to encapsulate the type checking behaviour. The node specializes itself based on values seen at run time; primarily when it encounters nil and literal values.

Finally, a few other minor changes:
- we now eagerly parse the built-in modules to extract their type information before that of the main program,
- we have added a new exception to the Kernel that is executed whenever a value fails to meet its expected type (it cannot respond to one of the names among the type's members), and finally
- we note which member is missing in the typing error's message.